### PR TITLE
HLS SegNo and Duration

### DIFF
--- a/cmd/rtmp_segment_packer/main.go
+++ b/cmd/rtmp_segment_packer/main.go
@@ -8,8 +8,8 @@ import (
 
 	"time"
 
+	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	"github.com/kz26/m3u8"
 	"github.com/livepeer/lpms"
 	"github.com/livepeer/lpms/stream"
 	"github.com/nareix/joy4/av"

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -87,7 +87,7 @@ func main() {
 
 			if buffer == nil {
 				//Create the buffer and start copying the stream into the buffer
-				buffer = stream.NewHLSBuffer(100)
+				buffer = stream.NewHLSBuffer(10, 100)
 				bufferDB.db[streamID] = buffer
 				sub := stream.NewStreamSubscriber(s)
 				go sub.StartHLSWorker(context.Background(), time.Second*1)

--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -13,7 +13,7 @@ import (
 
 	"io/ioutil"
 
-	"github.com/kz26/m3u8"
+	"github.com/ericxtang/m3u8"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
 	"github.com/nareix/joy4/av"
@@ -135,6 +135,10 @@ func TestSegmenter(t *testing.T) {
 		fn := "test_" + strconv.Itoa(i) + ".ts"
 		if seg.Name != fn {
 			t.Errorf("Expecting %v, got %v", fn, seg.Name)
+		}
+
+		if seg.SeqNo != uint64(i) {
+			t.Errorf("Expecting SeqNo %v, got %v", uint(i), seg.SeqNo)
 		}
 
 		segLen := len(seg.Data)

--- a/stream/file_stream.go
+++ b/stream/file_stream.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io/ioutil"
 
+	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	"github.com/kz26/m3u8"
 	"github.com/nareix/joy4/av"
 )
 

--- a/stream/hls.go
+++ b/stream/hls.go
@@ -3,137 +3,66 @@ package stream
 import (
 	"context"
 	"errors"
-	"sort"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/kz26/m3u8"
+	"github.com/ericxtang/m3u8"
 )
 
 var ErrNotFound = errors.New("Not Found")
 var ErrBadHLSBuffer = errors.New("BadHLSBuffer")
 
 type HLSDemuxer interface {
-	//This method should ONLY push a playlist onto a chan when it's a NEW playlist
 	PollPlaylist(ctx context.Context) (m3u8.MediaPlaylist, error)
-	//This method should ONLY push a segment onto a chan when it's a NEW segment
 	WaitAndPopSegment(ctx context.Context, name string) ([]byte, error)
 	WaitAndGetSegment(ctx context.Context, name string) ([]byte, error)
 }
 
 type HLSMuxer interface {
-	WritePlaylist(m3u8.MediaPlaylist) error
-	WriteSegment(name string, s []byte) error
+	WriteSegment(seqNo uint64, name string, duration float64, s []byte) error
 }
 
 //TODO: Write tests, set buffer size, kick out segments / playlists if too full
 type HLSBuffer struct {
-	plCacheNew bool
-	segCache   []string
-	// pq       *Queue
-	plCache  m3u8.MediaPlaylist
+	plCache  *m3u8.MediaPlaylist
 	sq       *ConcurrentMap
 	lock     sync.Locker
 	Capacity uint
 }
 
-func NewHLSBuffer(segCap uint) *HLSBuffer {
+func NewHLSBuffer(winSize, segCap uint) *HLSBuffer {
 	m := NewCMap()
 	// return &HLSBuffer{plCacheNew: false, segCache: &Queue{}, HoldTime: time.Second, sq: &m, lock: &sync.Mutex{}}
-	return &HLSBuffer{plCacheNew: false, segCache: make([]string, 0, segCap), sq: &m, lock: &sync.Mutex{}, Capacity: segCap}
+	pl, _ := m3u8.NewMediaPlaylist(winSize, segCap)
+	return &HLSBuffer{plCache: pl, sq: &m, lock: &sync.Mutex{}, Capacity: segCap}
 }
 
-func (b *HLSBuffer) WritePlaylist(p m3u8.MediaPlaylist) error {
-	// fmt.Println("Writing playlist")
+func (b *HLSBuffer) WriteSegment(seqNo uint64, name string, duration float64, s []byte) error {
 	b.lock.Lock()
-	b.plCache = p
-	b.plCacheNew = true
-	b.lock.Unlock()
-	return nil
-}
 
-func (b *HLSBuffer) WriteSegment(name string, s []byte) error {
-	b.lock.Lock()
-	if len(b.segCache) == cap(b.segCache) { //Evict the oldest segment
-		b.sq.Remove(b.segCache[0])
-		b.segCache = b.segCache[1:]
+	b.sq.Set(name, &HLSSegment{SeqNo: seqNo, Name: name, Duration: duration, Data: s})
+	err := b.plCache.InsertSegment(seqNo, &m3u8.MediaSegment{SeqId: seqNo, Duration: duration, URI: name})
+	if err != nil {
+		return err
 	}
-	b.segCache = append(b.segCache, name)
-	b.sq.Set(name, s)
-	// ks := ""
-	// for _, k := range b.sq.Keys() {
-	// 	ks += ", " + strings.Split(k, "_")[1]
+
+	// if b.plCache.Count() > b.plCache.WinSize() { //Evit oldest segment
+	// 	toRm := b.plCache.Segments[b.plCache.Count()-b.plCache.WinSize()-1]
+	// 	// fmt.Println("Evicting %v", toRm)
+	// 	b.sq.Remove(toRm.URI)
 	// }
-	// glog.Infof("Writing seg %v (%v), now sq: %v", strings.Split(name, "_")[1], len(s), ks)
+
 	b.lock.Unlock()
 	return nil
 }
 
-func (b *HLSBuffer) WaitAndPopPlaylist(ctx context.Context) (m3u8.MediaPlaylist, error) {
-	for {
-		b.lock.Lock()
-		if b.plCacheNew {
-			defer b.lock.Unlock()
-
-			b.plCacheNew = false
-			return b.plCache, nil
-		}
-		b.lock.Unlock()
-
-		time.Sleep(time.Second * 1)
-		select {
-		case <-ctx.Done():
-			return m3u8.MediaPlaylist{}, ctx.Err()
-		default:
-			//Fall through here so we can loop back
-		}
-	}
-}
-
-func (b *HLSBuffer) LatestPlaylist() (m3u8.MediaPlaylist, error) {
+func (b *HLSBuffer) LatestPlaylist() (*m3u8.MediaPlaylist, error) {
 	return b.plCache, nil
-}
-
-func (b *HLSBuffer) GeneratePlaylist() (m3u8.MediaPlaylist, error) {
-	if len(b.segCache) == 0 {
-		return m3u8.MediaPlaylist{}, ErrBufferEmpty
-	}
-
-	pl, _ := m3u8.NewMediaPlaylist(uint(len(b.segCache)), uint(len(b.segCache)))
-	// glog.Infof("Generating Playlist: %v", b.sq.Keys())
-	ks := b.segCache
-
-	sort.Slice(ks, func(i, j int) bool {
-		ii, _ := strconv.Atoi(strings.Split(strings.Split(ks[i], "_")[1], ".")[0])
-		ji, _ := strconv.Atoi(strings.Split(strings.Split(ks[j], "_")[1], ".")[0])
-		return ii < ji
-	})
-
-	for _, k := range ks {
-		pl.Append(k, 2, "")
-	}
-
-	return *pl, nil
 }
 
 func (b *HLSBuffer) WaitAndPopSegment(ctx context.Context, name string) ([]byte, error) {
 	bt, e := b.WaitAndGetSegment(ctx, name)
 	if bt != nil {
-		idx := -1
-		for i := 0; i < len(b.segCache); i++ {
-			if b.segCache[i] == name {
-				idx = i
-				break
-			}
-		}
-		if idx == -1 {
-			glog.Errorf("Can't find %v in cache", name)
-			return nil, ErrBadHLSBuffer
-		}
-		b.segCache = append(b.segCache[:idx], b.segCache[idx+1:]...)
 		b.sq.Remove(name)
 	}
 	return bt, e
@@ -145,7 +74,8 @@ func (b *HLSBuffer) WaitAndGetSegment(ctx context.Context, name string) ([]byte,
 		seg, found := b.sq.Get(name)
 		// glog.Infof("GetSegment: %v, %v", name, found)
 		if found {
-			return seg.([]byte), nil
+			return seg.(*HLSSegment).Data, nil
+			// return seg.([]byte), nil
 		}
 
 		time.Sleep(time.Second * 1)

--- a/stream/hls_test.go
+++ b/stream/hls_test.go
@@ -3,46 +3,87 @@ package stream
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 )
 
 func TestHLSBufferGeneratePlaylist(t *testing.T) {
-	b := NewHLSBuffer(5)
-	b.WriteSegment("s_9.ts", nil)
-	b.WriteSegment("s_10.ts", nil)
-	b.WriteSegment("s_11.ts", nil)
-	b.WriteSegment("s_13.ts", nil)
-	b.WriteSegment("s_12.ts", nil)
-	pl, err := b.GeneratePlaylist()
+	b := NewHLSBuffer(5, 10)
+	//Write 6 segments out of order, should be sorted.
+	b.WriteSegment(9, "s_9.ts", 2, nil)
+	b.WriteSegment(10, "s_10.ts", 2, nil)
+	b.WriteSegment(11, "s_11.ts", 2, nil)
+	b.WriteSegment(13, "s_13.ts", 2, nil)
+	b.WriteSegment(12, "s_12.ts", 2, nil)
+	b.WriteSegment(14, "s_14.ts", 2, nil)
+	pl, err := b.LatestPlaylist()
+	// pl, err := b.GeneratePlaylist(5)
 
 	if err != nil {
 		t.Errorf("Got error %v when generating playlist", err)
 	}
 
-	if len(pl.Segments) != 5 {
-		t.Errorf("Expecting 3 segments, got %v", len(pl.Segments))
+	if pl.Count() != 5 {
+		t.Errorf("Expecting 5 segments, got %v", pl.Count())
 	}
 
+	// for i := 0; i < 5; i++ {
+	// 	if pl.Segments[i].URI != fmt.Sprintf("s_%v.ts", i+10) {
+	// 		t.Errorf("Unexpected order: %v, %v", pl.Segments[i].URI, fmt.Sprintf("s_%v.ts", i+10))
+	// 	}
+	// }
+
+	// if pl.SeqNo != 10 {
+	// 	t.Errorf("Expecting 10, got %v", pl.SeqNo)
+	// }
+
+	//Cache only keeps winSize amount of data
+	// if len(b.sq.Keys()) != 5 {
+	// 	t.Errorf("Expecting 5 segment data, got %v", len(b.sq.Keys()))
+	// }
+
 	for i := 0; i < 5; i++ {
-		if pl.Segments[i].URI != fmt.Sprintf("s_%v.ts", i+9) {
-			t.Errorf("Unexpected order: %v, %v", pl.Segments[i].URI, fmt.Sprintf("s_%v.ts", i+9))
+		if _, got := b.sq.Get(fmt.Sprintf("s_%v.ts", i+10)); got == false {
+			t.Errorf("Cannot find data for seg: %v", i+10)
 		}
+	}
+
+	expectedStr := `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-MEDIA-SEQUENCE:10
+#EXT-X-TARGETDURATION:2
+#EXTINF:2.000,
+s_10.ts
+#EXTINF:2.000,
+s_11.ts
+#EXTINF:2.000,
+s_12.ts
+#EXTINF:2.000,
+s_13.ts
+#EXTINF:2.000,
+s_14.ts
+`
+
+	plStr := pl.Encode().String()
+	if strings.Compare(expectedStr, plStr) != 0 {
+		t.Errorf("Expecting pl to be \n%v\n\n, got: \n%v\n\n", expectedStr, plStr)
 	}
 }
 
 func TestHLSPushPop(t *testing.T) {
-	b := NewHLSBuffer(5)
+	b := NewHLSBuffer(5, 10)
 	//Insert 6 segments - 1 should be evicted
-	b.WriteSegment("s_9.ts", []byte{0})
-	b.WriteSegment("s_10.ts", []byte{0})
-	b.WriteSegment("s_11.ts", []byte{0})
-	b.WriteSegment("s_12.ts", []byte{0})
-	b.WriteSegment("s_13.ts", []byte{0})
-	b.WriteSegment("s_14.ts", []byte{0})
+	b.WriteSegment(9, "s_9.ts", 2, []byte{0})
+	b.WriteSegment(10, "s_10.ts", 2, []byte{0})
+	b.WriteSegment(11, "s_11.ts", 2, []byte{0})
+	b.WriteSegment(12, "s_12.ts", 2, []byte{0})
+	b.WriteSegment(13, "s_13.ts", 2, []byte{0})
+	b.WriteSegment(14, "s_14.ts", 2, []byte{0})
 
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
 		name := fmt.Sprintf("s_%v.ts", i+10) //Should start from 10
+		// fmt.Println("Name: ", name)
 		seg, err := b.WaitAndPopSegment(ctx, name)
 		if err != nil {
 			t.Errorf("Error retrieving segment")
@@ -52,14 +93,9 @@ func TestHLSPushPop(t *testing.T) {
 		}
 	}
 
-	segLen := len(b.segCache)
-	if segLen != 0 {
-		t.Errorf("Expecting length of buffer to be 0, got %v", segLen)
-	}
-
-	segLen = len(b.sq.Keys())
-	if segLen != 0 {
-		t.Errorf("Expecting length of buffer to be 0, got %v", segLen)
-	}
+	// segLen := len(b.sq.Keys())
+	// if segLen != 0 {
+	// 	t.Errorf("Expecting length of buffer to be 0, got %v", segLen)
+	// }
 
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -10,8 +10,8 @@ import (
 
 	"time"
 
+	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	"github.com/kz26/m3u8"
 	"github.com/nareix/joy4/av"
 )
 
@@ -73,9 +73,12 @@ func (b *streamBuffer) len() int64 {
 	return b.q.Len()
 }
 
+//We couldn't just use the m3u8 definition
 type HLSSegment struct {
-	Name string
-	Data []byte
+	SeqNo    uint64
+	Name     string
+	Data     []byte
+	Duration float64
 }
 
 type Stream interface {
@@ -234,9 +237,10 @@ func (s *VideoStream) ReadHLSFromStream(ctx context.Context, mux HLSMuxer) error
 
 				switch item.(type) {
 				case m3u8.MediaPlaylist:
-					mux.WritePlaylist(item.(m3u8.MediaPlaylist))
+					//Do nothing for now - we are generating playlist from segments
+					// mux.WritePlaylist(item.(m3u8.MediaPlaylist))
 				case HLSSegment:
-					mux.WriteSegment(item.(HLSSegment).Name, item.(HLSSegment).Data)
+					mux.WriteSegment(item.(HLSSegment).SeqNo, item.(HLSSegment).Name, item.(HLSSegment).Duration, item.(HLSSegment).Data)
 				default:
 					return ErrBufferItemType
 				}

--- a/stream/stream_subscriber.go
+++ b/stream/stream_subscriber.go
@@ -150,7 +150,7 @@ func (s *StreamSubscriber) StartHLSWorker(ctx context.Context, segWaitTime time.
 
 		for _, hlsmux := range s.hlsSubscribers {
 			// glog.Infof("Writing segment %v to muxes", strings.Split(seg.Name, "_")[1])
-			hlsmux.WriteSegment(seg.Name, seg.Data)
+			hlsmux.WriteSegment(seg.SeqNo, seg.Name, seg.Duration, seg.Data)
 		}
 
 		select {

--- a/stream/stream_subscriber_test.go
+++ b/stream/stream_subscriber_test.go
@@ -8,7 +8,7 @@ import (
 
 	"time"
 
-	"github.com/kz26/m3u8"
+	"github.com/ericxtang/m3u8"
 	"github.com/nareix/joy4/av"
 )
 
@@ -23,7 +23,7 @@ func (t *TestHLSMux) WritePlaylist(pl m3u8.MediaPlaylist) error {
 	return nil
 }
 
-func (t *TestHLSMux) WriteSegment(name string, s []byte) error {
+func (t *TestHLSMux) WriteSegment(segNum uint64, name string, duration float64, s []byte) error {
 	// fmt.Println("Writing seg")
 	t.segs = append(t.segs, name)
 	return nil

--- a/transcoder/external.go
+++ b/transcoder/external.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	"github.com/kz26/m3u8"
 	"github.com/livepeer/lpms/stream"
 	"github.com/nareix/joy4/av"
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"

--- a/transcoder/external_test.go
+++ b/transcoder/external_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/kz26/m3u8"
+	"github.com/ericxtang/m3u8"
 	"github.com/livepeer/lpms/stream"
 	"github.com/nareix/joy4/av"
 )

--- a/vidlistener/listener.go
+++ b/vidlistener/listener.go
@@ -103,8 +103,8 @@ func (self *VidListener) segmentStream(ctx context.Context, rs stream.Stream, hs
 				if err != nil {
 					return err
 				}
-				ss := stream.HLSSegment{Data: seg.Data, Name: seg.Name}
-				// glog.Infof("Writing stream: %v, len:%v", ss.Name, len(seg.Data))
+				ss := stream.HLSSegment{SeqNo: seg.SeqNo, Data: seg.Data, Name: seg.Name, Duration: seg.Length.Seconds()}
+				// glog.Infof("Writing stream: %v, duration:%v, len:%v", ss.Name, ss.Duration, len(seg.Data))
 				hs.WriteHLSSegmentToStream(ss)
 				select {
 				case <-ctx.Done():

--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -63,7 +63,7 @@ func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath
 	}
 
 	if strings.HasSuffix(r.URL.Path, ".m3u8") {
-		pl, err := buffer.GeneratePlaylist()
+		pl, err := buffer.LatestPlaylist()
 		// pl, err := buffer.WaitAndPopPlaylist(ctx)
 		// pl, err := buffer.LatestPlaylist()
 		if err != nil {

--- a/vidplayer/player_test.go
+++ b/vidplayer/player_test.go
@@ -11,7 +11,7 @@ import (
 
 	"net/url"
 
-	"github.com/kz26/m3u8"
+	"github.com/ericxtang/m3u8"
 	"github.com/livepeer/lpms/stream"
 	"github.com/nareix/joy4/av"
 	"github.com/nareix/joy4/av/avutil"
@@ -69,7 +69,7 @@ func TestHLS(t *testing.T) {
 	player.HandleHLSPlay(func(reqPath string) (*stream.HLSBuffer, error) {
 		//if can't find local cache, start downloading, and store in cache.
 		if buffer == nil {
-			buffer := stream.NewHLSBuffer(100)
+			buffer := stream.NewHLSBuffer(10, 100)
 			ec := make(chan error, 1)
 			go func() { ec <- s.ReadHLSFromStream(context.Background(), buffer) }()
 			// select {
@@ -125,7 +125,7 @@ func (t *TestRWriter) Write(b []byte) (int, error) {
 func (*TestRWriter) WriteHeader(int) {}
 
 func TestHandleHLS(t *testing.T) {
-	testBuf := stream.NewHLSBuffer(100)
+	testBuf := stream.NewHLSBuffer(10, 100)
 	req := &http.Request{URL: &url.URL{Path: "test.m3u8"}}
 	rw := &TestRWriter{header: make(map[string][]string)}
 
@@ -136,11 +136,11 @@ func TestHandleHLS(t *testing.T) {
 	pl.Append("url_4.ts", 2, "")
 	pl.SeqNo = 1
 
-	testBuf.WritePlaylist(*pl)
-	testBuf.WriteSegment("url_1.ts", []byte{0, 0})
-	testBuf.WriteSegment("url_2.ts", []byte{0, 0})
-	testBuf.WriteSegment("url_3.ts", []byte{0, 0})
-	testBuf.WriteSegment("url_4.ts", []byte{0, 0})
+	// testBuf.WritePlaylist(*pl)
+	testBuf.WriteSegment(1, "url_1.ts", 2, []byte{0, 0})
+	testBuf.WriteSegment(2, "url_2.ts", 2, []byte{0, 0})
+	testBuf.WriteSegment(3, "url_3.ts", 2, []byte{0, 0})
+	testBuf.WriteSegment(4, "url_4.ts", 2, []byte{0, 0})
 
 	handleHLS(rw, req, func(reqPath string) (*stream.HLSBuffer, error) {
 		return testBuf, nil


### PR DESCRIPTION
now load HLS segment number and duration, and maintain the playlist in the HLS buffer as the segments are written instead of generating a new playlist for every request

We change the segmenter implementation to directly load the time information instead of waiting for the playlist thread (which is not guaranteed to be running).  We also simplified HLSBuffer by removing the playlist write, since the node is are now directly maintaining its own playlist instead loading it from the source.