### PR TITLE
Video player fix

### DIFF
--- a/cmd/rtmp_segment_packer/main.go
+++ b/cmd/rtmp_segment_packer/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"net/url"
 	"strings"
 
 	"time"
@@ -265,17 +266,17 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	lpms := lpms.New("1935", "8000", "2435", "7935", "")
+	lpms := lpms.New("1935", "8000", "", "")
 	streamDB := &StreamDB{db: make(map[string]stream.Stream)}
 
 	lpms.HandleRTMPPublish(
 		//getStreamID
-		func(reqPath string) (string, error) {
-			return getStreamIDFromPath(reqPath), nil
+		func(url *url.URL) (string, error) {
+			return getStreamIDFromPath(url.Path), nil
 		},
 		//getStream
-		func(reqPath string) (stream.Stream, stream.Stream, error) {
-			streamID := getStreamIDFromPath(reqPath)
+		func(url *url.URL) (stream.Stream, stream.Stream, error) {
+			streamID := getStreamIDFromPath(url.Path)
 			stream1 := NewSegmentStream(streamID)
 			stream2 := NewSegmentStream(streamID)
 			streamDB.db[streamID] = stream1

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -26,18 +27,18 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	lpms := lpms.New("1935", "8000", "2435", "7935", "")
+	lpms := lpms.New("1935", "8000", "", "")
 	streamDB := &StreamDB{db: make(map[string]stream.Stream)}
 	bufferDB := &BufferDB{db: make(map[string]*stream.HLSBuffer)}
 
 	lpms.HandleRTMPPublish(
 		//getStreamID
-		func(reqPath string) (string, error) {
-			return getStreamIDFromPath(reqPath), nil
+		func(url *url.URL) (string, error) {
+			return getStreamIDFromPath(url.Path), nil
 		},
 		//getStream
-		func(reqPath string) (stream.Stream, stream.Stream, error) {
-			rtmpStreamID := getStreamIDFromPath(reqPath)
+		func(url *url.URL) (stream.Stream, stream.Stream, error) {
+			rtmpStreamID := getStreamIDFromPath(url.Path)
 			hlsStreamID := rtmpStreamID + "_hls"
 			rtmpStream := stream.NewVideoStream(rtmpStreamID, stream.RTMP)
 			hlsStream := stream.NewVideoStream(hlsStreamID, stream.HLS)

--- a/segmenter/video_segmenter.go
+++ b/segmenter/video_segmenter.go
@@ -92,7 +92,7 @@ func (s *FFMpegVideoSegmenter) RTMPToHLS(ctx context.Context, opt SegmenterOptio
 
 	var cmd *exec.Cmd
 
-	cmd = exec.Command(path.Join(s.ffmpegPath, "ffmpeg"), "-i", s.LocalRtmpUrl, "-vcodec", "copy", "-acodec", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "segment", "-muxdelay", "0", "-segment_list", plfn, tsfn)
+	cmd = exec.Command(path.Join(s.ffmpegPath, "ffmpeg"), "-i", s.LocalRtmpUrl, "-vcodec", "copy", "-acodec", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "segment", "-segment_time", "8", "-muxdelay", "0", "-segment_list", plfn, tsfn)
 
 	err = cmd.Start()
 	if err != nil {

--- a/stream/stream_subscriber.go
+++ b/stream/stream_subscriber.go
@@ -131,6 +131,22 @@ func (s *StreamSubscriber) UnsubscribeHLS(muxID string) error {
 	return nil
 }
 
+func (s *StreamSubscriber) UnsubscribeAll() error {
+	if s.hlsSubscribers != nil {
+		for k := range s.hlsSubscribers {
+			delete(s.hlsSubscribers, k)
+		}
+	}
+
+	if s.rtmpSubscribers != nil {
+		for k := range s.rtmpSubscribers {
+			delete(s.rtmpSubscribers, k)
+		}
+	}
+
+	return nil
+}
+
 func (s *StreamSubscriber) StartHLSWorker(ctx context.Context, segWaitTime time.Duration) error {
 	lastSegTimer := time.Now()
 	for {
@@ -170,7 +186,7 @@ func (s *StreamSubscriber) GetRTMPBuffer(subID string) av.Muxer {
 	return s.rtmpSubscribers[subID]
 }
 
-func (s *StreamSubscriber) HLSSubscribers() []string {
+func (s *StreamSubscriber) HLSSubscribersReport() []string {
 	var res []string
 	for sub, v := range s.hlsSubscribers {
 		res = append(res, fmt.Sprintf("%v: %v", reflect.TypeOf(v), sub))
@@ -178,7 +194,7 @@ func (s *StreamSubscriber) HLSSubscribers() []string {
 	return res
 }
 
-func (s *StreamSubscriber) RTMPSubscribers() []string {
+func (s *StreamSubscriber) RTMPSubscribersReport() []string {
 	var res []string
 	for sub, v := range s.rtmpSubscribers {
 		res = append(res, fmt.Sprintf("%v: %v", reflect.TypeOf(v), sub))

--- a/vidlistener/listener_test.go
+++ b/vidlistener/listener_test.go
@@ -2,6 +2,7 @@ package vidlistener
 
 import (
 	"fmt"
+	"net/url"
 	"os/exec"
 	"testing"
 	"time"
@@ -14,10 +15,10 @@ func TestListener(t *testing.T) {
 	server := &joy4rtmp.Server{Addr: ":1937"}
 	listener := &VidListener{RtmpServer: server}
 	listener.HandleRTMPPublish(
-		func(reqPath string) (string, error) {
+		func(url *url.URL) (string, error) {
 			return "test", nil
 		},
-		func(reqPath string) (stream.Stream, stream.Stream, error) {
+		func(url *url.URL) (stream.Stream, stream.Stream, error) {
 			// return errors.New("Some Error")
 			return stream.NewVideoStream("test", stream.RTMP), stream.NewVideoStream("test", stream.HLS), nil
 		},

--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -2,9 +2,11 @@ package vidplayer
 
 import (
 	"context"
+	"io/ioutil"
 	"mime"
 	"net/http"
 	"path"
+	"path/filepath"
 
 	"strings"
 
@@ -22,6 +24,7 @@ var PlaylistWaittime = 6 * time.Second
 //VidPlayer is the module that handles playing video. For now we only support RTMP and HLS play.
 type VidPlayer struct {
 	RtmpServer *joy4rtmp.Server
+	VodPath    string
 }
 
 //HandleRTMPPlay is the handler when there is a RTMP request for a video. The source should write
@@ -48,6 +51,36 @@ func (s *VidPlayer) HandleHLSPlay(getHLSBuffer func(reqPath string) (*stream.HLS
 	http.HandleFunc("/stream/", func(w http.ResponseWriter, r *http.Request) {
 		handleHLS(w, r, getHLSBuffer)
 	})
+
+	//To play video from static files
+	http.HandleFunc("/vod/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".m3u8") {
+			plName := filepath.Join(s.VodPath, strings.Replace(r.URL.Path, "/vod/", "", -1))
+			dat, err := ioutil.ReadFile(plName)
+			if err != nil {
+				glog.Errorf("Cannot find file: %v", plName)
+				return
+			}
+			w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Cache-Control", "max-age=5")
+			w.Write(dat)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, ".ts") {
+			segName := filepath.Join(s.VodPath, strings.Replace(r.URL.Path, "/vod/", "", -1))
+			dat, err := ioutil.ReadFile(segName)
+			if err != nil {
+				glog.Errorf("Cannot find file: %v", segName)
+				return
+			}
+			w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Write(dat)
+			return
+		}
+	})
 	return nil
 }
 
@@ -66,6 +99,21 @@ func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath
 	}
 
 	if strings.HasSuffix(r.URL.Path, ".m3u8") {
+		// Just an experiment to create a fake master playlist.  Commenting it out for now, maybe useful later when we re-visit adaptive bitrate streaming.
+		// if strings.Contains(r.URL.Path, "_master") {
+		// 	pl := *m3u8.NewMasterPlaylist()
+		// 	regex, _ := regexp.Compile("\\/stream\\/([[:alpha:]]|\\d)*")
+		// 	match := regex.FindString(r.URL.Path)
+		// 	uri := strings.Replace(match, "/stream/", "", -1)
+		// 	uri = strings.Replace(uri, "_master", "", -1)
+		// 	pl.Append(uri+".m3u8", nil, m3u8.VariantParams{Bandwidth: 520929})
+
+		// 	w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
+		// 	w.Header().Set("Access-Control-Allow-Origin", "*")
+		// 	w.Header().Set("Cache-Control", "max-age=5")
+		// 	w.Write(pl.Encode().Bytes())
+		// 	return
+		// }
 		var pl *m3u8.MediaPlaylist
 		sleepTime := 0 * time.Millisecond
 		for sleepTime < PlaylistWaittime { //Try to wait a little for the first segments
@@ -88,10 +136,12 @@ func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath
 		// }
 		// glog.Infof("Writing playlist seg: %v", segs)
 
-		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
+		w.Header().Set("Content-Type", "application/x-mpegURL")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Cache-Control", "max-age=5")
 
+		// pl.MediaType = m3u8.EVENT
 		_, err = w.Write(pl.Encode().Bytes())
 		if err != nil {
 			glog.Errorf("Error writing playlist to ResponseWriter: %v", err)
@@ -108,7 +158,6 @@ func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath
 	if strings.HasSuffix(r.URL.Path, ".ts") {
 		pathArr := strings.Split(r.URL.Path, "/")
 		segName := pathArr[len(pathArr)-1]
-		// seg, err := buffer.WaitAndPopSegment(ctx, segName)
 		seg, err := buffer.WaitAndGetSegment(ctx, segName)
 		if err != nil {
 			glog.Errorf("Error getting HLS segment %v: %v", segName, err)

--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -86,6 +86,10 @@ func (s *VidPlayer) HandleHLSPlay(getHLSBuffer func(reqPath string) (*stream.HLS
 
 func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath string) (*stream.HLSBuffer, error)) {
 	glog.Infof("LPMS got HTTP request @ %v", r.URL.Path)
+	w.Header().Set("Content-Type", "application/x-mpegURL")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Cache-Control", "max-age=5")
 
 	if !strings.HasSuffix(r.URL.Path, ".m3u8") && !strings.HasSuffix(r.URL.Path, ".ts") {
 		http.Error(w, "LPMS only accepts HLS requests over HTTP (m3u8, ts).", 500)
@@ -135,11 +139,6 @@ func handleHLS(w http.ResponseWriter, r *http.Request, getHLSBuffer func(reqPath
 		// 	segs = segs + ", " + strings.Split(s.URI, "_")[1]
 		// }
 		// glog.Infof("Writing playlist seg: %v", segs)
-
-		w.Header().Set("Content-Type", "application/x-mpegURL")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Cache-Control", "max-age=5")
 
 		// pl.MediaType = m3u8.EVENT
 		_, err = w.Write(pl.Encode().Bytes())


### PR DESCRIPTION
Make mobile publishing work.  Changes:
* Make sure we always set the same headers - that way the CDN will invalidate quickly and always look for new content, even with the URL is the same.
* Clean up files for the segmenter - had to do this because we are now streaming to the same ID over and over.
* Add VOD path
* Did a test with master playlist, but not useful for now.  Let's leave it in - maybe it'll be useful when we do adaptive bitrate streaming.