### PR TITLE
stability improvement

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
     # - "$HOME/ffmpeg-static"
   override:
     - go get github.com/livepeer/lpms/cmd/example
+    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull
     - cd $HOME/.go_workspace/src/github.com/livepeer/lpms/ && git pull
     - npm install -g ffmpeg-static
 

--- a/stream/basic_hls_videostream.go
+++ b/stream/basic_hls_videostream.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	lpmon "github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/common"
 )
 
 const DefaultMediaPlLen = uint(500)
+
+// const DefaultMediaWinLen = uint(5)
 const DefaultSegWaitTime = time.Second * 10
 const SegWaitInterval = time.Second
 
@@ -27,15 +29,16 @@ type BasicHLSVideoStream struct {
 	strmID              string
 	segWaitTime         time.Duration
 	subscriber          func(HLSVideoStream, string, *HLSSegment)
+	winSize             uint
 
 	//Keep track of the non-variant stream separately
 	strmMediaPlCache *m3u8.MediaPlaylist
 	strmLock         sync.Locker
 }
 
-func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration) *BasicHLSVideoStream {
+func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration, wSize uint) *BasicHLSVideoStream {
 	mpl := m3u8.NewMasterPlaylist()
-	pl, _ := m3u8.NewMediaPlaylist(DefaultMediaPlLen, DefaultMediaPlLen)
+	pl, _ := m3u8.NewMediaPlaylist(wSize, DefaultMediaPlLen)
 	strm := &BasicHLSVideoStream{
 		masterPlCache:       mpl,
 		variantMediaPlCache: make(map[string]*m3u8.MediaPlaylist),
@@ -44,7 +47,8 @@ func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration) *BasicHLSV
 		strmID:              strmID,
 		segWaitTime:         segWaitTime,
 		strmMediaPlCache:    pl,
-		strmLock:            &sync.Mutex{}}
+		strmLock:            &sync.Mutex{},
+		winSize:             wSize}
 
 	return strm
 }
@@ -68,6 +72,9 @@ func (s *BasicHLSVideoStream) GetMasterPlaylist() (*m3u8.MasterPlaylist, error) 
 //GetVariantPlaylist returns the media playlist represented by the streamID
 func (s *BasicHLSVideoStream) GetVariantPlaylist(strmID string) (*m3u8.MediaPlaylist, error) {
 	if strmID == s.GetStreamID() {
+		if s.strmMediaPlCache.Count() < s.winSize {
+			return nil, nil
+		}
 		return s.strmMediaPlCache, nil
 	}
 
@@ -76,26 +83,21 @@ func (s *BasicHLSVideoStream) GetVariantPlaylist(strmID string) (*m3u8.MediaPlay
 		return nil, ErrNotFound
 	}
 
+	// glog.Infof("Variant pl len: %v, %v", pl.Count(), pl)
+	if pl.Count() < s.winSize {
+		return nil, nil
+	}
+
 	return pl, nil
 }
 
 //GetHLSSegment gets the HLS segment.  It blocks until something is found, or timeout happens.
 func (s *BasicHLSVideoStream) GetHLSSegment(strmID string, segName string) (*HLSSegment, error) {
-	start := time.Now()
-	for {
-		if time.Since(start) > s.segWaitTime {
-			return nil, ErrNotFound
-		}
-
-		seg, ok := s.sqMap[sqMapKey(strmID, segName)]
-		if !ok {
-			lpmon.Instance().LogBuffer(strmID)
-			time.Sleep(SegWaitInterval)
-			continue
-		}
-
-		return seg, nil
+	seg, ok := s.sqMap[sqMapKey(strmID, segName)]
+	if !ok {
+		return nil, ErrNotFound
 	}
+	return seg, nil
 }
 
 //AddVariant adds a new variant playlist (and therefore, a new HLS video stream) to the master playlist.
@@ -132,13 +134,19 @@ func (s *BasicHLSVideoStream) AddVariant(strmID string, variant *m3u8.Variant) e
 
 //AddHLSSegment adds the hls segment to the right stream
 func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) error {
-	// glog.Infof("Adding segment: %v", seg.Name)
+	if _, ok := s.sqMap[sqMapKey(strmID, seg.Name)]; ok {
+		return nil //Already have the seg.
+	}
+	glog.V(common.VERBOSE).Infof("Adding segment: %v", seg.Name)
 	if strmID == s.GetStreamID() {
 		s.strmLock.Lock()
 		defer s.strmLock.Unlock()
-		if err := s.strmMediaPlCache.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
-			glog.Errorf("Error inserting segment %v: %v", seg.Name, err)
+		if err := s.strmMediaPlCache.AppendSegment(&m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
+			glog.Errorf("Error appending segment %v: %v", seg.Name, err)
 			return ErrAddHLSSegment
+		}
+		if s.strmMediaPlCache.Count() > s.winSize {
+			s.strmMediaPlCache.Remove()
 		}
 		s.sqMap[sqMapKey(strmID, seg.Name)] = seg
 		if s.subscriber != nil {
@@ -155,11 +163,14 @@ func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) erro
 	defer lock.Unlock()
 
 	//Add segment to media playlist
-	pl, err := s.GetVariantPlaylist(strmID)
-	if err != nil {
-		return err
+	pl, ok := s.variantMediaPlCache[strmID]
+	if !ok {
+		return ErrNotFound
 	}
-	pl.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name})
+	pl.AppendSegment(&m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name})
+	if pl.Count() > s.winSize {
+		pl.Remove()
+	}
 
 	//Add to buffer
 	s.sqMap[sqMapKey(strmID, seg.Name)] = seg

--- a/transcoder/ffmpeg_segment_transcoder.go
+++ b/transcoder/ffmpeg_segment_transcoder.go
@@ -45,7 +45,7 @@ func (t *FFMpegSegmentTranscoder) Transcode(d []byte) ([][]byte, error) {
 	//ffmpeg -i seg.ts -c:v libx264 -s 426:240 -r 30 -mpegts_copyts 1 -minrate 700k -maxrate 700k -bufsize 700k -threads 1 out3.ts
 	args := make([]string, 0, 0)
 	for i, p := range t.tProfiles {
-		args = append(args, []string{"-c:v", "libx264", "-s", p.Resolution, "-mpegts_copyts", "1", "-minrate", p.Bitrate, "-maxrate", p.Bitrate, "-bufsize", p.Bitrate, "-r", fmt.Sprintf("%d", p.Framerate), "-threads", "1", path.Join(t.workDir, fmt.Sprintf("out%v%v", i, inName))}...)
+		args = append(args, []string{"-c:v", "libx264", "-s", p.Resolution, "-minrate", p.Bitrate, "-maxrate", p.Bitrate, "-bufsize", p.Bitrate, "-r", fmt.Sprintf("%d", p.Framerate), "-threads", "1", "-copyts", path.Join(t.workDir, fmt.Sprintf("out%v%v", i, inName))}...)
 	}
 	cmd = exec.Command(path.Join(t.ffmpegPath, "ffmpeg"), append([]string{"-i", path.Join(t.workDir, inName)}, args...)...)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
- We make a change to the HLS stream to keep a buffer of at least 3 segments.  Until then, the video will not be available.  This increases the video delay to about 30 seconds, but improves the playback stability.

- We also remove the waiting pattern in GetHLSSegment, so the user of the library is not forced to wait.

- We add a flag to the ffmpeg transcode command to keep the timing information.