### PR TITLE
transcoder: Fix double free on invalid output.

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -162,6 +162,7 @@ static void free_output(struct output_ctx *octx)
       avio_closep(&octx->oc->pb);
     }
     avformat_free_context(octx->oc);
+    octx->oc = NULL;
   }
   if (octx->vc) avcodec_free_context(&octx->vc);
   if (octx->ac) avcodec_free_context(&octx->ac);

--- a/transcoder/ffmpeg_segment_transcoder.go
+++ b/transcoder/ffmpeg_segment_transcoder.go
@@ -13,13 +13,12 @@ import (
 
 //SegmentTranscoder transcodes segments individually.  This is a simple wrapper for calling FFMpeg on the command line.
 type FFMpegSegmentTranscoder struct {
-	tProfiles  []ffmpeg.VideoProfile
-	ffmpegPath string
-	workDir    string
+	tProfiles []ffmpeg.VideoProfile
+	workDir   string
 }
 
-func NewFFMpegSegmentTranscoder(ps []ffmpeg.VideoProfile, ffmpegp, workd string) *FFMpegSegmentTranscoder {
-	return &FFMpegSegmentTranscoder{tProfiles: ps, ffmpegPath: ffmpegp, workDir: workd}
+func NewFFMpegSegmentTranscoder(ps []ffmpeg.VideoProfile, workd string) *FFMpegSegmentTranscoder {
+	return &FFMpegSegmentTranscoder{tProfiles: ps, workDir: workd}
 }
 
 func (t *FFMpegSegmentTranscoder) Transcode(fname string) ([][]byte, error) {

--- a/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/transcoder/ffmpeg_segment_transcoder_test.go
@@ -23,7 +23,7 @@ func TestTrans(t *testing.T) {
 		ffmpeg.P576p30fps16x9,
 	}
 	ffmpeg.InitFFmpeg()
-	tr := NewFFMpegSegmentTranscoder(configs, "", "./")
+	tr := NewFFMpegSegmentTranscoder(configs, "./")
 	r, err := tr.Transcode("test.ts")
 	ffmpeg.DeinitFFmpeg()
 	if err != nil {
@@ -68,7 +68,7 @@ func TestTooManyProfiles(t *testing.T) {
 		ffmpeg.P144p30fps16x9,
 	}
 	ffmpeg.InitFFmpeg()
-	tr := NewFFMpegSegmentTranscoder(configs, "", "./")
+	tr := NewFFMpegSegmentTranscoder(configs, "./")
 	_, err := tr.Transcode("test.ts")
 	ffmpeg.DeinitFFmpeg()
 	if err == nil {
@@ -90,7 +90,7 @@ func NewStreamTest(t *testing.T, configs []ffmpeg.VideoProfile) (*StreamTest, er
 		return nil, errors.New(fmt.Sprintf("Unable to get tempdir ", err))
 	}
 	f := fmt.Sprintf("%v/tmp.ts", d)
-	tr := NewFFMpegSegmentTranscoder(configs, "", "./")
+	tr := NewFFMpegSegmentTranscoder(configs, "./")
 	ffmpeg.InitFFmpeg()
 	return &StreamTest{Tempdir: d, Tempfile: f, Transcoder: tr}, nil
 }
@@ -146,7 +146,7 @@ func TestInvalidFile(t *testing.T) {
 	configs := []ffmpeg.VideoProfile{
 		ffmpeg.P144p30fps16x9,
 	}
-	tr := NewFFMpegSegmentTranscoder(configs, "", "./")
+	tr := NewFFMpegSegmentTranscoder(configs, "./")
 	ffmpeg.InitFFmpeg()
 	defer ffmpeg.DeinitFFmpeg()
 

--- a/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/transcoder/ffmpeg_segment_transcoder_test.go
@@ -171,5 +171,21 @@ func TestInvalidFile(t *testing.T) {
 		t.Errorf("Did not get the expected error while transcoding: %v", err)
 	}
 
+	// test invalid output params
+	vp := ffmpeg.VideoProfile{
+		Name: "OddDimension", Bitrate: "100k", Framerate: 10,
+		AspectRatio: "6:5", Resolution: "852x481"}
+	st, err := NewStreamTest(t, []ffmpeg.VideoProfile{vp})
+	defer st.Close()
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = st.Transcoder.Transcode("test.ts")
+	// XXX Make the returned error more descriptive;
+	// here x264 doesn't like odd heights
+	if err == nil || err.Error() != "Generic error in an external library" {
+		t.Error(err)
+	}
+
 	// XXX test bad output file names / directories
 }


### PR DESCRIPTION
Fixes a segfault.

Also a small API cleanup.