### PR TITLE
Fix crash and disconnect listener on `gotStream` error

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -257,7 +257,7 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
   }
 
   if (!(fmt->flags & AVFMT_NOFILE)) {
-    avio_open(&octx->oc->pb, octx->fname, AVIO_FLAG_WRITE);
+    ret = avio_open(&octx->oc->pb, octx->fname, AVIO_FLAG_WRITE);
     if (ret < 0) em_err("Error opening output file\n");
   }
 

--- a/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/transcoder/ffmpeg_segment_transcoder_test.go
@@ -187,5 +187,10 @@ func TestInvalidFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	// XXX test bad output file names / directories
+	// test bad output file names / directories
+	tr = NewFFMpegSegmentTranscoder(configs, "/asdf/qwerty!")
+	_, err = tr.Transcode("test.ts")
+	if err == nil || err.Error() != "No such file or directory" {
+		t.Error(err)
+	}
 }

--- a/vidlistener/listener.go
+++ b/vidlistener/listener.go
@@ -46,6 +46,8 @@ func (self *VidListener) HandleRTMPPublish(
 		err = gotStream(conn.URL, s)
 		if err != nil {
 			glog.Errorf("Error RTMP gotStream handler: %v", err)
+			endStream(conn.URL, s)
+			conn.Close()
 			cancel()
 			return
 		}


### PR DESCRIPTION
transcoder: Set return code when opening output file.  …
Fixes a crash. Let that be a lesson to follow through on TODOs
within the code; a test would have caught the issue instantly.

listener: Disconnect publisher if gotStream returns error.

Note that ^ is a semantic change to the API. Made to accommodate https://github.com/livepeer/go-livepeer/pull/380 , but I think the behavior still makes sense on its own.