### PR TITLE
ffmpeg: Fix crash in length check.

### DIFF
--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -50,4 +50,9 @@ func TestLength(t *testing.T) {
 		t.Error("Did not get an error on nb packets check where one was expected")
 	}
 
+	// check invalid file
+	err = CheckMediaLen("nonexistent", ts, nb_packets)
+	if err == nil || err.Error() != "No such file or directory" {
+		t.Error("Did not get the expected error: ", err)
+	}
 }

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -766,7 +766,7 @@ int lpms_length(char *inp, int ts_max, int packet_max)
     AVRational limit_tb   = {1, 1000}; // MilliSeconds
     int64_t pts_max       = ts_max;
     struct input_metrics im[LPMS_MAX_INPUT_STREAMS];
-    AVPacket pkt;
+    AVPacket pkt          = {0};
 
     ret = avformat_open_input(&ic, inp, NULL, NULL);
     if (ret < 0) len_err("len: Unable to open input\n");


### PR DESCRIPTION
Crashed if the file was invalid or nonexistent.