### PR TITLE
Misc fixes to LPMS

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -76,23 +76,6 @@ func Transcode(input string, workDir string, ps []VideoProfile) error {
 	return nil
 }
 
-// Check media length up to given limits for timestamp (ms) and packet count.
-// XXX someday return some actual stats, if limits aren't hit
-func CheckMediaLen(fname string, ts_max int, packet_max int) error {
-	f := C.CString(fname)
-	defer C.free(unsafe.Pointer(f))
-	tm := C.int(ts_max)
-	pm := C.int(packet_max)
-	ret := int(C.lpms_length(f, tm, pm))
-	if 0 != ret {
-		if nil == ErrorMap[ret] {
-			return errors.New("MediaStats Failure")
-		}
-		return ErrorMap[ret]
-	}
-	return nil
-}
-
 func InitFFmpeg() {
 	C.lpms_init()
 }

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -216,3 +216,68 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// TODO set / check sar/dar values?
 }
+
+func TestTranscoder_SampleRate(t *testing.T) {
+
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	// Craft an input with 48khz audio
+	cmd := `
+		set -eux
+		cd $0
+
+		# borrow the test.ts from the transcoder dir, output with 48khz audio
+		ffmpeg -loglevel warning -i "$1/../transcoder/test.ts" -c:v copy -af 'aformat=sample_fmts=fltp:channel_layouts=stereo:sample_rates=48000' -c:a aac -t 1.1 test.ts
+
+		# sanity check results to ensure preconditions
+		ffprobe -loglevel warning -show_streams -select_streams a test.ts | grep sample_rate=48000
+
+		# output timestamp check as a script to reuse for post-transcoding check
+		cat <<- 'EOF' > check_ts
+			set -eux
+			# ensure 1 second of timestamps add up to within 2.1% of 90khz (mpegts timebase)
+			# 2.1% is the margin of error, 1024 / 48000 (% increase per frame)
+			# 1024 = samples per frame, 48000 = samples per second
+
+			# select last frame pts, subtract from first frame pts, check diff
+			ffprobe -loglevel warning -show_frames  -select_streams a "$2"  | grep pkt_pts= | head -"$1" | awk 'BEGIN{FS="="} ; NR==1 { fst = $2 } ; END{ diff=(($2-fst)/90000); exit diff <= 0.979 || diff >= 1.021 }'
+		EOF
+		chmod +x check_ts
+
+		# check timestamps at the given frame offsets. 47 = ceil(48000/1024)
+		./check_ts 47 test.ts
+
+		# check failing cases; use +2 since we may be +/- the margin of error
+		[ $(./check_ts 45 test.ts || echo "shouldfail") = "shouldfail" ]
+		[ $(./check_ts 49 test.ts || echo "shouldfail") = "shouldfail" ]
+	`
+	run(cmd)
+
+	err := Transcode(dir+"/test.ts", dir, []VideoProfile{P240p30fps16x9})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Ensure transcoded sample rate is 44k.1hz and check timestamps
+	cmd = `
+		set -eux
+		cd "$0"
+		ffprobe -loglevel warning -show_streams -select_streams a out0test.ts | grep sample_rate=44100
+
+		# Sample rate = 44.1khz, samples per frame = 1024
+		# Frames per second = ceil(44100/1024) = 44
+
+		# Technically check_ts margin of error is 2.1% due to 48khz rate
+		# At 44.1khz, error is 2.3% so we'll just accept the tighter bounds
+
+		# check timestamps at the given frame offsets. 44 = ceil(48000/1024)
+		./check_ts 44 out0test.ts
+
+		# check failing cases; use +2 since we may be +/- the margin of error
+		[ $(./check_ts 46 out0test.ts || echo "shouldfail") = "shouldfail" ]
+		[ $(./check_ts 42 out0test.ts || echo "shouldfail") = "shouldfail" ]
+	`
+	run(cmd)
+
+}

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1,7 +1,9 @@
 package ffmpeg
 
 import (
+	"io/ioutil"
 	"math"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -54,4 +56,68 @@ func TestLength(t *testing.T) {
 	if err == nil || err.Error() != "No such file or directory" {
 		t.Error("Did not get the expected error: ", err)
 	}
+}
+
+func TestSegmenter_StreamOrdering(t *testing.T) {
+	// Ensure segmented output contains [video, audio] streams in that order
+	// regardless of stream ordering in the input
+
+	dir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	InitFFmpeg() // hide some log noise
+
+	// Craft an input that has a subtitle, audio and video stream, in that order
+	cmd := `
+	    set -eux
+	    cd "$0"
+
+		# generate subtitle file
+		cat <<- EOF > inp.srt
+			1
+			00:00:00,000 --> 00:00:01,000
+			hi
+		EOF
+
+		# borrow the test.ts from the transcoder dir, output with 3 streams
+		ffmpeg -loglevel warning -i inp.srt -i "$1/../transcoder/test.ts" -c:a copy -c:v copy -c:s mov_text -t 1 -map 0:s -map 1:a -map 1:v test.mp4
+
+		# some sanity checks. these will exit early on a nonzero code
+		# check stream count, then indexes of subtitle, audio and video
+		[ $(ffprobe -loglevel warning -i test.mp4 -show_streams | grep index | wc -l) -eq 3 ]
+		ffprobe -loglevel warning -i test.mp4 -show_streams -select_streams s | grep index=0
+		ffprobe -loglevel warning -i test.mp4 -show_streams -select_streams a | grep index=1
+		ffprobe -loglevel warning -i test.mp4 -show_streams -select_streams v | grep index=2
+	`
+	out, err := exec.Command("bash", "-c", cmd, dir, wd).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// actually do the segmentation
+	err = RTMPToHLS(dir+"/test.mp4", dir+"/out.m3u8", dir+"/out_%d.ts", "1", 0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check stream ordering in output file. Should be video, then audio
+	cmd = `
+		set -eux
+		cd $0
+		[ $(ffprobe -loglevel warning -i out_0.ts -show_streams | grep index | wc -l) -eq 2 ]
+		ffprobe -loglevel warning -i out_0.ts -show_streams -select_streams v | grep index=0
+		ffprobe -loglevel warning -i out_0.ts -show_streams -select_streams a | grep index=1
+	`
+	out, err = exec.Command("bash", "-c", cmd, dir).CombinedOutput()
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(string(out))
 }

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -116,8 +116,136 @@ func TestSegmenter_StreamOrdering(t *testing.T) {
 		ffprobe -loglevel warning -i out_0.ts -show_streams -select_streams a | grep index=1
 	`
 	out, err = exec.Command("bash", "-c", cmd, dir).CombinedOutput()
+	t.Log(string(out))
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestTranscoder_UnevenRes(t *testing.T) {
+	// Ensure transcoding still works on input with uneven resolutions
+	// and that aspect ratio is maintained
+
+	dir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	InitFFmpeg() // hide some log noise
+
+	// Craft an input with an uneven res
+	cmd := `
+	    set -eux
+	    cd "$0"
+
+		# borrow the test.ts from the transcoder dir, output with 123x456 res
+		ffmpeg -loglevel warning -i "$1/../transcoder/test.ts" -c:a copy -c:v mpeg4 -s 123x456 test.mp4
+
+		# sanity check resulting resolutions
+		ffprobe -loglevel warning -i test.mp4 -show_streams -select_streams v | grep width=123
+		ffprobe -loglevel warning -i test.mp4 -show_streams -select_streams v | grep height=456
+
+		# and generate another sample with an odd value in the larger dimension
+		ffmpeg -loglevel warning -i "$1/../transcoder/test.ts" -c:a copy -c:v mpeg4 -s 123x457 test_larger.mp4
+		ffprobe -loglevel warning -i test_larger.mp4 -show_streams -select_streams v | grep width=123
+		ffprobe -loglevel warning -i test_larger.mp4 -show_streams -select_streams v | grep height=457
+
+	`
+	out, err := exec.Command("bash", "-c", cmd, dir, wd).CombinedOutput()
 	t.Log(string(out))
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = Transcode(dir+"/test.mp4", dir, []VideoProfile{P240p30fps16x9})
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = Transcode(dir+"/test_larger.mp4", dir, []VideoProfile{P240p30fps16x9})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check output resolutions
+	cmd = `
+		set -eux
+		cd "$0"
+		ffprobe -loglevel warning -show_streams -select_streams v out0test.mp4 | grep width=64
+		ffprobe -loglevel warning -show_streams -select_streams v out0test.mp4 | grep height=240
+		ffprobe -loglevel warning -show_streams -select_streams v out0test_larger.mp4 | grep width=64
+		ffprobe -loglevel warning -show_streams -select_streams v out0test_larger.mp4 | grep height=240
+	`
+	out, err = exec.Command("bash", "-c", cmd, dir).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Transpose input and do the same checks as above.
+	cmd = `
+		set -eux
+		cd "$0"
+		ffmpeg -loglevel warning -i test.mp4 -c:a copy -c:v mpeg4 -vf transpose transposed.mp4
+
+		# sanity check resolutions
+		ffprobe -loglevel warning -show_streams -select_streams v transposed.mp4 | grep width=456
+		ffprobe -loglevel warning -show_streams -select_streams v transposed.mp4 | grep height=123
+	`
+	out, err = exec.Command("bash", "-c", cmd, dir, wd).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = Transcode(dir+"/transposed.mp4", dir, []VideoProfile{P240p30fps16x9})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check output resolutions for transposed input
+	cmd = `
+		set -eux
+		cd "$0"
+		ffprobe -loglevel warning -show_streams -select_streams v out0transposed.mp4 | grep width=426
+		ffprobe -loglevel warning -show_streams -select_streams v out0transposed.mp4 | grep height=114
+	`
+	run(cmd)
+
+	// check special case of square resolutions
+	cmd = `
+		set -eux
+		cd "$0"
+		ffmpeg -loglevel warning -i test.mp4 -c:a copy -c:v mpeg4 -s 123x123 square.mp4
+
+		# sanity check resolutions
+		ffprobe -loglevel warning -show_streams -select_streams v square.mp4 | grep width=123
+		ffprobe -loglevel warning -show_streams -select_streams v square.mp4 | grep height=123
+	`
+	run(cmd)
+
+	err = Transcode(dir+"/square.mp4", dir, []VideoProfile{P240p30fps16x9})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check output resolutions are still square
+	cmd = `
+		set -eux
+		cd "$0"
+		ls
+		ffprobe -loglevel warning -i out0square.mp4 -show_streams -select_streams v | grep width=426
+		ffprobe -loglevel warning -i out0square.mp4 -show_streams -select_streams v | grep height=426
+	`
+	out, err = exec.Command("bash", "-c", cmd, dir).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// TODO set / check sar/dar values?
 }

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2,61 +2,10 @@ package ffmpeg
 
 import (
 	"io/ioutil"
-	"math"
 	"os"
 	"os/exec"
-	"strconv"
-	"strings"
 	"testing"
 )
-
-func TestLength(t *testing.T) {
-	InitFFmpeg()
-	inp := "../transcoder/test.ts"
-	// Extract packet count of sample from ffprobe
-	// XXX enhance MediaLength to actually return media stats
-	cmd := "ffprobe -loglevel quiet -hide_banner "
-	cmd += "-select_streams v  -show_streams -count_packets "
-	cmd += inp + " | grep -oP 'nb_read_packets=\\K.*$'"
-	out, err := exec.Command("bash", "-c", cmd).Output()
-	nb_packets, err := strconv.Atoi(strings.TrimSpace(string(out)))
-	if err != nil {
-		t.Error("Could not extract packet count from sample", err)
-	}
-
-	// Extract length of test vid (in seconds) from ffprobe
-	cmd = "ffprobe -loglevel quiet -hide_banner "
-	cmd += "-select_streams v  -show_streams -count_packets "
-	cmd += inp + " | grep -oP 'duration=\\K.*$'"
-	out, err = exec.Command("bash", "-c", cmd).Output()
-	ts_f, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
-	if err != nil {
-		t.Error("Could not extract timestamp from sample", err)
-	}
-	ts := int(math.Ceil(ts_f * 1000.0))
-
-	// sanity check baseline numbers
-	err = CheckMediaLen(inp, ts, nb_packets)
-	if err != nil {
-		t.Error("Media sanity check failed")
-	}
-
-	err = CheckMediaLen(inp, ts/2, nb_packets)
-	if err == nil {
-		t.Error("Did not get an error on ts check where one was expected")
-	}
-
-	err = CheckMediaLen(inp, ts, nb_packets/2)
-	if err == nil {
-		t.Error("Did not get an error on nb packets check where one was expected")
-	}
-
-	// check invalid file
-	err = CheckMediaLen("nonexistent", ts, nb_packets)
-	if err == nil || err.Error() != "No such file or directory" {
-		t.Error("Did not get the expected error: ", err)
-	}
-}
 
 func TestSegmenter_StreamOrdering(t *testing.T) {
 	// Ensure segmented output contains [video, audio] streams in that order

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -241,6 +241,7 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
     if (fmt->flags & AVFMT_GLOBALHEADER) ac->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     ret = avcodec_open2(ac, codec, NULL);
     if (ret < 0) em_err("Error opening audio encoder\n");
+    av_buffersink_set_frame_size(octx->af.sink_ctx, ac->frame_size);
 
     // audio stream in muxer
     st = avformat_new_stream(oc, NULL);

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -107,8 +107,8 @@ int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char* seg_time, char 
     if (pkt.stream_index == stream_map[0]) pkt.stream_index = 0;
     else if (pkt.stream_index == stream_map[1]) pkt.stream_index = 1;
     else goto r2hloop_end;
-    ist = ic->streams[pkt.stream_index];
-    ost = oc->streams[stream_map[pkt.stream_index]];
+    ist = ic->streams[stream_map[pkt.stream_index]];
+    ost = oc->streams[pkt.stream_index];
     int64_t dts_next = pkt.dts, dts_prev = prev_ts[pkt.stream_index];
     if (oc->streams[pkt.stream_index]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
         AV_NOPTS_VALUE == dts_prev &&

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -93,6 +93,7 @@ int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char* seg_time, char 
   av_dict_set(&md, "hls_time", seg_time, 0);
   av_dict_set(&md, "hls_segment_filename", ts_tmpl, 0);
   av_dict_set(&md, "start_number", seg_start, 0);
+  av_dict_set(&md, "hls_flags", "delete_segments", 0);
   ret = avformat_write_header(oc, &md);
   if (ret < 0) r2h_err("Error writing header\n");
 

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -649,7 +649,8 @@ int lpms_transcode(char *inp, output_params *params, int nb_outputs)
     if (params[i].fps.den) octx->fps = params[i].fps;
     if (ictx.vc) {
       char filter_str[256];
-      snprintf(filter_str, sizeof filter_str, "fps=fps=%d/%d,scale=%dx%d:force_original_aspect_ratio=decrease", octx->fps.num, octx->fps.den, octx->width, octx->height);
+      // preserve aspect ratio along the larger dimension when rescaling
+      snprintf(filter_str, sizeof filter_str, "fps=fps=%d/%d,scale='w=if(gte(iw,ih),%d,-2):h=if(lt(iw, ih),%d,-2)'", octx->fps.num, octx->fps.den, octx->width, octx->height);
       ret = init_video_filters(&ictx, octx, filter_str);
       if (ret < 0) main_err("Unable to open video filter");
     }

--- a/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/transcoder/ffmpeg_segment_transcoder_test.go
@@ -178,7 +178,7 @@ func TestInvalidFile(t *testing.T) {
 	// test invalid output params
 	vp := ffmpeg.VideoProfile{
 		Name: "OddDimension", Bitrate: "100k", Framerate: 10,
-		AspectRatio: "6:5", Resolution: "852x481"}
+		AspectRatio: "6:5", Resolution: "853x481"}
 	st, err := NewStreamTest(t, []ffmpeg.VideoProfile{vp})
 	defer st.Close()
 	if err != nil {


### PR DESCRIPTION
* d9e09b21a4fd8d2a1a6c858e708a512c4540038a - segmenter: FIx a crash and verify output stream ordering
* 54f87083a40654c78928bea748e40c72a1b57476 - transcoder: Fix rounding with odd-valued rescaled resolutions.
* f1d09dcf30bba01151b33298d91f211f8d21c126 - medialen: Remove media stats checker.
* 8fc5c435b8403325c7f795bb143694b14ff76775 - segmenter: Delete segments as they fall off the playlist.
* c2df2d703e0c627a4b21670087f448a7f24f2f1d - ffmpeg: Incorporate a test helper to reduce boilerplate.
* 63bcda9b3a1f3cb624028aa50fcb951a638bced5 - transcoder: Fix buzzing in resampled audio output.