### PR TITLE
Update README re: ports used for example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Running golang unit tests (`test.sh`) requires the `ffmpeg` and `ffprobe` execut
 
 The test LPMS server exposes a few different endpoints:
 1. `rtmp://localhost:1935/stream/test` for uploading/viewing RTMP video stream.
-2. `http://localhost:8000/stream/test_hls.m3u8` for consuming the HLS video stream.
+2. `http://localhost:7935/stream/test_hls.m3u8` for consuming the HLS video stream.
 
 Do the following steps to view a live stream video:
 1. Start LPMS by running `go run cmd/example/main.go`
@@ -45,7 +45,7 @@ For OBS, fill in Settings->Stream->URL to be rtmp://localhost:1935
 I0324 09:44:14.639405   80673 listener.go:28] RTMP server got upstream
 I0324 09:44:14.639429   80673 listener.go:42] Got RTMP Stream: test
 ```
-4. Now you have a RTMP video stream running, we can view it from the server.  Simply run `ffplay http://localhost:8000/stream/test.m3u8`, you should see the hls video playback.
+4. Now you have a RTMP video stream running, we can view it from the server.  Simply run `ffplay http://localhost:7935/stream/test.m3u8`, you should see the hls video playback.
 
 
 ### Integrating LPMS


### PR DESCRIPTION
It's currently 7935, not 8000.