### PR TITLE
 In case segment was not found, return 404 instead of 500

### DIFF
--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -161,7 +161,11 @@ func handleLive(w http.ResponseWriter, r *http.Request,
 		seg, err := getSegment(r.URL)
 		if err != nil {
 			glog.Errorf("Error getting segment %v: %v", r.URL, err)
-			http.Error(w, "Error getting segment", 500)
+			if err == ErrNotFound {
+				http.Error(w, "ErrNotFound", 404)
+			} else {
+				http.Error(w, "Error getting segment", 500)
+			}
 			return
 		}
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))

--- a/vidplayer/player_test.go
+++ b/vidplayer/player_test.go
@@ -72,6 +72,10 @@ func stubGetSeg(url *url.URL) ([]byte, error) {
 	return []byte("testseg"), nil
 }
 
+func stubGetSegNotFound(url *url.URL) ([]byte, error) {
+	return nil, ErrNotFound
+}
+
 func TestHLS(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handleLive(rec, httptest.NewRequest("GET", "/badpath", strings.NewReader("")), stubGetMasterPL, stubGetMediaPL, stubGetSeg)
@@ -121,6 +125,13 @@ func TestHLS(t *testing.T) {
 	}
 	if string(res) != "testseg" {
 		t.Errorf("Expecting testseg, got %v", string(res))
+	}
+
+	//Test not found segment
+	rec = httptest.NewRecorder()
+	handleLive(rec, httptest.NewRequest("GET", "/seg.ts", strings.NewReader("")), stubGetMasterPL, stubGetMediaPL, stubGetSegNotFound)
+	if rec.Result().StatusCode != 404 {
+		t.Errorf("Expecting 404, but got %v", rec.Result().StatusCode)
 	}
 }
 


### PR DESCRIPTION
Right now if `getSegment` returns `ErrNotFound` error player return HTTP status coded 500, which is misleading. PR fixes that.