### PR TITLE
add content-length header to video segments

### DIFF
--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"strings"
 
@@ -167,6 +168,7 @@ func handleLive(w http.ResponseWriter, r *http.Request,
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Content-Length", strconv.Itoa(len(seg)))
 		_, err = w.Write(seg)
 		if err != nil {
 			glog.Errorf("Error writting HLS segment %v: %v", r.URL, err)

--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -108,6 +108,7 @@ func handleLive(w http.ResponseWriter, r *http.Request,
 		http.Error(w, "LPMS only accepts HLS requests over HTTP (m3u8, ts).", 500)
 	}
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 	w.Header().Set("Cache-Control", "max-age=5")
 
 	if strings.HasSuffix(r.URL.Path, ".m3u8") {
@@ -167,6 +168,7 @@ func handleLive(w http.ResponseWriter, r *http.Request,
 		}
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(r.URL.Path)))
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Content-Length", strconv.Itoa(len(seg)))
 		_, err = w.Write(seg)
@@ -200,6 +202,7 @@ func handleVOD(url *url.URL, vodPath string, w http.ResponseWriter) error {
 		}
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(url.Path)))
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 		w.Header().Set("Cache-Control", "max-age=5")
 		w.Write(dat)
 	}
@@ -214,6 +217,7 @@ func handleVOD(url *url.URL, vodPath string, w http.ResponseWriter) error {
 		}
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(url.Path)))
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 		w.Write(dat)
 	}
 


### PR DESCRIPTION
See title.

FWIW I didn't test LPMS itself — I tested this by building it into go-livepeer and looking at output from there. Seems pretty straightforward, though.

```
▶ curl -i --head https://bbb.stream.town/stream/499d46af/P360p30fps16x9/288.ts
HTTP/2 200
server: nginx/1.14.2
date: Thu, 07 Mar 2019 23:09:07 GMT
content-length: 230300
access-control-allow-origin: *
access-control-expose-headers: Content-Length
cache-control: max-age=5
via: 1.1 google
alt-svc: clear
```

Fixes #108 