### PR TITLE
Preliminary nvidia support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,39 @@ To handle HLS playback:
 		})
 ```
 
+### GPU Support
+
+Processing on Nvidia GPUs is supported. To enable this capability, FFmpeg needs
+to be built with GPU support. See the
+[FFmpeg guidelines](https://trac.ffmpeg.org/wiki/HWAccelIntro#NVENCNVDEC) on
+this.
+
+To execute the nvidia tests within the `ffmpeg` directory, run this command:
+
+```
+go test -tag=nvidia -run Nvidia
+
+```
+
+To run the tests on a particular GPU, use the GPU_DEVICE environment variable:
+
+```
+# Runs on GPU number 3
+GPU_DEVICE=3 go test -tag nvidia -run Nvidia
+```
+
+Aside from the tests themselves, there is a
+[sample program](https://github.com/livepeer/lpms/blob/master/cmd/transcoding/transcoding.go)
+that can be used as a reference to the LPMS GPU transcoding API. The sample
+program can select GPU or software processing via CLI flags. Run the sample
+program via:
+
+```
+# software processing
+go run cmd/transcoding/transcoding.go transcoder/test.ts P144p30fps16x9,P240p30fps16x9 sw
+
+# nvidia processing, GPU number 2
+go run cmd/transcoding/transcoding.go transcoder/test.ts P144p30fps16x9,P240p30fps16x9 nv 2
+```
+
 You can follow the development of LPMS and Livepeer @ our [forum](http://forum.livepeer.org)

--- a/cmd/transcoding/transcoding.go
+++ b/cmd/transcoding/transcoding.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/livepeer/lpms/ffmpeg"
+)
+
+func validRenditions() []string {
+	valids := make([]string, len(ffmpeg.VideoProfileLookup))
+	for p, _ := range ffmpeg.VideoProfileLookup {
+		valids = append(valids, p)
+	}
+	return valids
+}
+
+func main() {
+	if len(os.Args) <= 3 {
+		panic("Usage: <input file> <output renditions, comma separated> <sw/nv>")
+	}
+	str2accel := func(inp string) (ffmpeg.Acceleration, string) {
+		if inp == "nv" {
+			return ffmpeg.Nvidia, "nv"
+		}
+		return ffmpeg.Software, "sw"
+	}
+	str2profs := func(inp string) []ffmpeg.VideoProfile {
+		profs := []ffmpeg.VideoProfile{}
+		strs := strings.Split(inp, ",")
+		for _, k := range strs {
+			p, ok := ffmpeg.VideoProfileLookup[k]
+			if !ok {
+				panic(fmt.Sprintf("Invalid rendition %s. Valid renditions are:\n%s", k, validRenditions()))
+			}
+			profs = append(profs, p)
+		}
+		return profs
+	}
+	fname := os.Args[1]
+	profiles := str2profs(os.Args[2])
+	accel, lbl := str2accel(os.Args[3])
+
+	profs2opts := func(profs []ffmpeg.VideoProfile) []ffmpeg.TranscodeOptions {
+		opts := []ffmpeg.TranscodeOptions{}
+		for i := range profs {
+			o := ffmpeg.TranscodeOptions{
+				Oname:   fmt.Sprintf("out_%s_%d_out.mkv", lbl, i),
+				Profile: profs[i],
+				Accel:   accel,
+			}
+			opts = append(opts, o)
+		}
+		return opts
+	}
+	options := profs2opts(profiles)
+
+	var dev string
+	if accel == ffmpeg.Nvidia {
+		if len(os.Args) <= 4 {
+			panic("Expected device number")
+		}
+		dev = os.Args[4]
+	}
+
+	ffmpeg.InitFFmpeg()
+
+	fmt.Printf("Setting fname %s encoding %d renditions with %v\n", fname, len(options), lbl)
+	err := ffmpeg.Transcode2(&ffmpeg.TranscodeOptionsIn{
+		Fname:  fname,
+		Accel:  accel,
+		Device: dev,
+	}, options)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -29,8 +29,9 @@ const (
 )
 
 type TranscodeOptionsIn struct {
-	Fname string
-	Accel Acceleration
+	Fname  string
+	Accel  Acceleration
+	Device string
 }
 
 type TranscodeOptions struct {
@@ -164,7 +165,12 @@ func Transcode2(input *TranscodeOptionsIn, ps []TranscodeOptions) error {
 			w: C.int(w), h: C.int(h), bitrate: C.int(bitrate),
 			vencoder: venc, vfilters: vfilt}
 	}
-	inp := &C.input_params{fname: fname, hw_type: hw_type}
+	var device *C.char
+	if input.Device != "" {
+		device = C.CString(input.Device)
+		defer C.free(unsafe.Pointer(device))
+	}
+	inp := &C.input_params{fname: fname, hw_type: hw_type, device: device}
 	ret := int(C.lpms_transcode(inp, (*C.output_params)(&params[0]), C.int(len(params))))
 	if 0 != ret {
 		glog.Infof("Transcoder Return : %v\n", Strerror(ret))

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -163,7 +163,7 @@ func Transcode2(input *TranscodeOptionsIn, ps []TranscodeOptions) error {
 		filters := fmt.Sprintf("fps=%d/%d,%s='w=if(gte(iw,ih),%d,-2):h=if(lt(iw,ih),%d,-2)'", param.Framerate, 1, scale_filter, w, h)
 		if input.Accel != Software && p.Accel == Software {
 			// needed for hw dec -> hw rescale -> sw enc
-			filters = filters + ",hwdownload,format=yuv420p"
+			filters = filters + ":format=yuv420p,hwdownload"
 		}
 		venc := C.CString(encoder)
 		vfilt := C.CString(filters)

--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -34,6 +34,7 @@ func error_map() map[int]error {
 		desc string
 	}{
 		{code: C.lpms_ERR_INPUT_PIXFMT, desc: "Unsupported input pixel format"},
+		{code: C.lpms_ERR_FILTERS, desc: "Error initializing filtergraph"},
 	}
 	for _, v := range lpmsErrors {
 		m[int(v.code)] = errors.New(v.desc)

--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 // #cgo pkg-config: libavformat
 //#include "ffmpeg_errors.h"
+//#include "lpms_ffmpeg.h"
 import "C"
 import (
 	"encoding/binary"
@@ -25,6 +26,17 @@ func error_map() map[int]error {
 		if "UNKNOWN_ERROR" != v {
 			m[i] = errors.New(v)
 		}
+	}
+
+	// Add in LPMS specific errors
+	lpmsErrors := []struct {
+		code C.int
+		desc string
+	}{
+		{code: C.lpms_ERR_INPUT_PIXFMT, desc: "Unsupported input pixel format"},
+	}
+	for _, v := range lpmsErrors {
+		m[int(v.code)] = errors.New(v.desc)
 	}
 
 	return m

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -6,6 +6,9 @@
 #include <libavfilter/buffersrc.h>
 #include <libavutil/opt.h>
 
+// Not great to appropriate internal API like this...
+const int lpms_ERR_INPUT_PIXFMT = FFERRTAG('I','N','P','X');
+
 //
 // Internal transcoder data structures
 //
@@ -362,6 +365,7 @@ static int open_input(input_params *params, struct input_ctx *ctx)
       frames->height = vc->height;
       vc->extra_hw_frames = 16 + 1; // H.264 max refs but increases mem usage
       ret = av_hwframe_ctx_init(vc->hw_frames_ctx);
+      if (AVERROR(ENOSYS) == ret) ret = lpms_ERR_INPUT_PIXFMT; // most likely
       if (ret < 0) dd_err("Unable to initialize a hardware frame pool\n")
     }
     ret = avcodec_open2(vc, codec, NULL);

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -775,7 +775,8 @@ int lpms_transcode(input_params *inp, output_params *params, int nb_outputs)
     av_frame_unref(dframe);
     ret = process_in(&ictx, dframe, &ipkt);
     if (ret == AVERROR_EOF) break;
-    else if (ret < 0) goto whileloop_end; // XXX fix
+                            // Bail out on streams that appear to be broken
+    else if (ret < 0) main_err("transcoder: Could not decode; stopping\n");
     ist = ictx.ic->streams[ipkt.stream_index];
 
     for (i = 0; i < nb_outputs; i++) {
@@ -796,7 +797,7 @@ int lpms_transcode(input_params *inp, output_params *params, int nb_outputs)
 
       ret = process_out(&ictx, octx, encoder, ost, filter, dframe);
       if (AVERROR(EAGAIN) == ret || AVERROR_EOF == ret) continue;
-      else if (ret < 0) main_err("transcoder: verybad\n");
+      else if (ret < 0) main_err("transcoder: Error encoding\n");
     }
 
 whileloop_end:

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -619,7 +619,7 @@ int process_out(struct output_ctx *octx, AVCodecContext *encoder, AVStream *ost,
   //     hasn't been a problem in practice (so far)
   if (AVMEDIA_TYPE_AUDIO == ost->codecpar->codec_type) {
       if (octx->drop_ts == AV_NOPTS_VALUE) octx->drop_ts = pkt.pts;
-      if (pkt.pts && pkt.pts == octx->drop_ts) return 0;
+      if (pkt.pts && pkt.pts == octx->drop_ts) goto proc_cleanup;
   }
 
   ret = av_interleaved_write_frame(octx->oc, &pkt);

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -26,6 +26,8 @@ struct filter_ctx {
 
 struct output_ctx {
   char *fname;         // required output file name
+  char *vencoder;      // required output video encoder
+  char *vfilters;      // required output video filters
   int width, height, bitrate; // w, h, br required
   AVRational fps;
   AVFormatContext *oc; // muxer required
@@ -662,6 +664,8 @@ int lpms_transcode(char *inp, output_params *params, int nb_outputs)
     octx->fname = params[i].fname;
     octx->width = params[i].w;
     octx->height = params[i].h;
+    octx->vencoder = params[i].vencoder;
+    octx->vfilters = params[i].vfilters;
     if (params[i].bitrate) octx->bitrate = params[i].bitrate;
     if (params[i].fps.den) octx->fps = params[i].fps;
     if (ictx.vc) {

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -285,7 +285,7 @@ static void free_input(struct input_ctx *inctx)
   if (inctx->ac) avcodec_free_context(&inctx->ac);
 }
 
-static int open_input(char *inp, struct input_ctx *ctx)
+static int open_input(input_params *params, struct input_ctx *ctx)
 {
 #define dd_err(msg) { \
   if (!ret) ret = -1; \
@@ -294,6 +294,7 @@ static int open_input(char *inp, struct input_ctx *ctx)
 }
   AVCodec *codec = NULL;
   AVFormatContext *ic   = NULL;
+  char *inp = params->fname;
 
   // open demuxer
   int ret = avformat_open_input(&ic, inp, NULL, NULL);
@@ -640,7 +641,7 @@ proc_cleanup:
 
 #define MAX_OUTPUT_SIZE 10
 
-int lpms_transcode(char *inp, output_params *params, int nb_outputs)
+int lpms_transcode(input_params *inp, output_params *params, int nb_outputs)
 {
 #define main_err(msg) { \
   if (!ret) ret = AVERROR(EINVAL); \
@@ -656,6 +657,7 @@ int lpms_transcode(char *inp, output_params *params, int nb_outputs)
   memset(&ictx, 0, sizeof ictx);
   memset(outputs, 0, sizeof outputs);
 
+  if (!inp) main_err("transcoder: Missing input params\n")
   if (nb_outputs > MAX_OUTPUT_SIZE) main_err("transcoder: Too many outputs\n");
 
   // populate input context

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -344,7 +344,7 @@ static int open_input(input_params *params, struct input_ctx *ctx)
     if (params->hw_type != AV_HWDEVICE_TYPE_NONE) {
       // First set the hw device then set the hw frame
       AVHWFramesContext *frames;
-      ret = av_hwdevice_ctx_create(&ctx->hw_device_ctx, params->hw_type, NULL, NULL, 0);
+      ret = av_hwdevice_ctx_create(&ctx->hw_device_ctx, params->hw_type, params->device, NULL, 0);
       if (ret < 0) dd_err("Unable to open hardware context for decoding\n")
       ctx->hw_type = params->hw_type;
       vc->hw_device_ctx = av_buffer_ref(ctx->hw_device_ctx);

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -1,3 +1,6 @@
+#ifndef _LPMS_FFMPEG_H_
+#define _LPMS_FFMPEG_H_
+
 #include <libavutil/rational.h>
 
 typedef struct {
@@ -7,7 +10,7 @@ typedef struct {
 } output_params;
 
 void lpms_init();
-void lpms_deinit();
 int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char *seg_start);
 int  lpms_transcode(char *inp, output_params *params, int nb_outputs);
-int  lpms_length(char *inp, int ts_max, int packet_max);
+
+#endif // _LPMS_FFMPEG_H_

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -4,6 +4,9 @@
 #include <libavutil/hwcontext.h>
 #include <libavutil/rational.h>
 
+// LPMS specific errors
+extern const int lpms_ERR_INPUT_PIXFMT;
+
 typedef struct {
   char *fname;
   char *vencoder;

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -1,6 +1,7 @@
 #ifndef _LPMS_FFMPEG_H_
 #define _LPMS_FFMPEG_H_
 
+#include <libavutil/hwcontext.h>
 #include <libavutil/rational.h>
 
 typedef struct {
@@ -11,8 +12,15 @@ typedef struct {
   AVRational fps;
 } output_params;
 
+typedef struct {
+  char *fname;
+
+  // Optional hardware acceleration
+  enum AVHWDeviceType hw_type;
+} input_params;
+
 void lpms_init();
 int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char *seg_start);
-int  lpms_transcode(char *inp, output_params *params, int nb_outputs);
+int  lpms_transcode(input_params *inp, output_params *params, int nb_outputs);
 
 #endif // _LPMS_FFMPEG_H_

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -5,6 +5,8 @@
 
 typedef struct {
   char *fname;
+  char *vencoder;
+  char *vfilters;
   int w, h, bitrate;
   AVRational fps;
 } output_params;

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -17,6 +17,7 @@ typedef struct {
 
   // Optional hardware acceleration
   enum AVHWDeviceType hw_type;
+  char *device;
 } input_params;
 
 void lpms_init();

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -6,6 +6,7 @@
 
 // LPMS specific errors
 extern const int lpms_ERR_INPUT_PIXFMT;
+extern const int lpms_ERR_FILTERS;
 
 typedef struct {
   char *fname;

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -1,0 +1,294 @@
+// +build nvidia
+
+package ffmpeg
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestNvidia_Transcoding(t *testing.T) {
+	// Various Nvidia GPU tests for encoding + decoding
+	// XXX what is missing is a way to verify these are *actually* running on GPU!
+
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+    set -eux
+    cd "$0"
+
+    # set up initial input; truncate test.ts file
+    ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
+  `
+	run(cmd)
+
+	var err error
+	fname := dir + "/test.ts"
+	oname := dir + "/out.ts"
+	prof := P240p30fps16x9
+
+	// hw dec, sw enc
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Nvidia,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Software,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// sw dec, hw enc
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Software,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// hw enc + dec
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Nvidia,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// software transcode for image quality check
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Software,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   dir + "/sw.ts",
+			Profile: prof,
+			Accel:   Software,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmd = `
+    set -eux
+    cd "$0"
+    # compare using ssim and generate stats file
+    ffmpeg -loglevel warning -i out.ts -i sw.ts -lavfi '[0:v][1:v]ssim=stats.log' -f null -
+    # check image quality; ensure that no more than 5 frames have ssim < 0.95
+    grep -Po 'All:\K\d+.\d+' stats.log | awk '{ if ($1 < 0.95) count=count+1 } END{ exit count > 5 }'
+  `
+	run(cmd)
+
+}
+
+func TestNvidia_Transcoding_Multiple(t *testing.T) {
+
+	// Tests multiple encoding profiles.
+	// May be skipped in 'short' mode.
+
+	if testing.Short() {
+		t.Skip("Skipping encoding multiple profiles")
+	}
+
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+    set -eux
+    cd "$0"
+
+    # set up initial input; truncate test.ts file
+    ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
+
+    # sanity check input dimensions for resolution pass through test
+    ffprobe -loglevel warning -show_streams -select_streams v test.ts | grep width=1280
+    ffprobe -loglevel warning -show_streams -select_streams v test.ts | grep height=720
+  `
+	run(cmd)
+
+	fname := dir + "/test.ts"
+	prof := P240p30fps16x9
+	orig := P720p30fps16x9
+
+	mkoname := func(i int) string { return fmt.Sprintf("%s/%d.ts", dir, i) }
+	out := []TranscodeOptions{
+		TranscodeOptions{
+			Oname: mkoname(0),
+			// pass through resolution has different behavior;
+			// basically bypasses the scale filter
+			Profile: orig,
+			Accel:   Nvidia,
+		},
+		TranscodeOptions{
+			Oname:   mkoname(1),
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+		TranscodeOptions{
+			Oname:   mkoname(2),
+			Profile: orig,
+			Accel:   Software,
+		},
+		TranscodeOptions{
+			Oname:   mkoname(3),
+			Profile: prof,
+			Accel:   Software,
+		},
+		// another gpu rendition for good measure?
+		TranscodeOptions{
+			Oname:   mkoname(4),
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+	}
+
+	// generate the above outputs with the given decoder
+	test := func(decoder Acceleration) {
+		err := Transcode2(&TranscodeOptionsIn{
+			Fname: fname,
+			Accel: decoder,
+		}, out)
+		if err != nil {
+			t.Error(err)
+		}
+		// XXX should compare ssim image quality of results
+	}
+	test(Nvidia)
+	test(Software)
+}
+
+func TestNvidia_Devices(t *testing.T) {
+
+	// XXX need to verify these are running on the correct GPU
+	//     not just that the code runs
+
+	device := os.Getenv("GPU_DEVICE")
+	if device == "" {
+		t.Skip("Skipping device specific tests; no GPU_DEVICE set")
+	}
+
+	_, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	var err error
+	fname := "../transcoder/test.ts"
+	oname := dir + "/out.ts"
+	prof := P240p30fps16x9
+
+	// hw enc, sw dec
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname:  fname,
+		Accel:  Nvidia,
+		Device: device,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Software,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// sw dec, hw enc
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Software,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+			Device:  device,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// hw enc + dec
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname:  fname,
+		Accel:  Nvidia,
+		Device: device,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// hw enc + hw dec, separate devices
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname:  fname,
+		Accel:  Nvidia,
+		Device: "0",
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+			Device:  "1",
+		},
+	})
+	if err != ErrTranscoderInp {
+		t.Error(err)
+	}
+
+	// invalid device for decoding
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname:  fname,
+		Accel:  Nvidia,
+		Device: "9999",
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Software,
+		},
+	})
+	if err == nil || err.Error() != "Unknown error occurred" {
+		t.Error(fmt.Errorf(fmt.Sprintf("\nError being: '%v'\n", err)))
+	}
+
+	// invalid device for encoding
+	err = Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Software,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+			Device:  "9999",
+		},
+	})
+	if err == nil || err.Error() != "Unknown error occurred" {
+		t.Error(fmt.Errorf(fmt.Sprintf("\nError being: '%v'\n", err)))
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,11 @@ go test -logtostderr=true
 t7=$?
 cd ..
 
-if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0))
+echo 'Testing example program'
+go run cmd/transcoding/transcoding.go transcoder/test.ts P144p30fps16x9,P240p30fps16x9 sw
+t8=$?
+
+if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0||$t8!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1


### PR DESCRIPTION
This patch set introduces preliminary support for processing on nvidia GPUs. 

* Decode
* Encode
* Rescale
* Selectable GPUs

Various combinations are supported:

* Software-only processing
* Software decode, GPU rescale, GPU encode
* GPU decode, GPU rescale, software encode
* GPU-only processing

As much processing is kept on the GPU device as possible. Eg, if rescaling is required while only one of encode / decode is run on the GPU, then the rescaling will be done on the GPU. Only one GPU is used at a time for a given transcode.

A new API is introduced to support GPU : `Transcode2` . The old `Transcode` API has been internally retrofitted to use the new API with software-only processing, but to take advantage of GPUs, the new API will need to be used. (https://github.com/livepeer/lpms/commit/19dd8cb49ca136520596beb0cd9157dc6cfdc28c). We can remove the old `Transcode` API after the new `Transcode2` has been fully integrated into the goclient.

Sample program : https://github.com/livepeer/lpms/commit/890aab5bc160122ae625a22c47adec255ec48ca4

There are some test cases for GPU processing, however they require:
* Proper hardware
* Run with the `-tag=nvidia` flag
* Commit: https://github.com/livepeer/lpms/commit/36aa9dfe2a3dadd8a6ba190f6d79dacb28120c65

See the README for further details.