### PR TITLE
Make RTMP handling more thread safe

### DIFF
--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -108,10 +108,10 @@ func TestSegmenter(t *testing.T) {
 
 	//Create a test stream from stub
 	strm := &TestStream{}
-	strmUrl := fmt.Sprintf("rtmp://localhost:%v/stream/%v", "1935", strm.GetStreamID())
+	strmUrl := fmt.Sprintf("rtmp://localhost:%v/stream/%v", "1939", strm.GetStreamID())
 	opt := SegmenterOptions{SegLength: time.Second * 4}
 	vs := NewFFMpegVideoSegmenter(workDir, strm.GetStreamID(), strmUrl, opt)
-	server := &rtmp.Server{Addr: ":1935"}
+	server := &rtmp.Server{Addr: ":1939"}
 	player := vidplayer.NewVidPlayer(server, "", nil)
 
 	player.HandleRTMPPlay(

--- a/stream/basic_rtmp_videostream_test.go
+++ b/stream/basic_rtmp_videostream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 //Testing WriteRTMP errors
 var ErrPacketRead = errors.New("packet read error")
 var ErrStreams = errors.New("streams error")
+var ErrMuxClosed = errors.New("packet muxer closed")
 
 type BadStreamsDemuxer struct{}
 
@@ -62,6 +64,9 @@ func TestWriteBasicRTMPErrors(t *testing.T) {
 type PacketsDemuxer struct {
 	c           *Counter
 	CalledClose bool
+
+	wait         bool          // whether to pause before returning a packet
+	startReading chan struct{} // signal to start returning packets
 }
 
 func (d *PacketsDemuxer) Close() error {
@@ -72,6 +77,10 @@ func (d *PacketsDemuxer) Streams() ([]av.CodecData, error) {
 	return []av.CodecData{h264parser.CodecData{}}, nil
 }
 func (d *PacketsDemuxer) ReadPacket() (av.Packet, error) {
+	if d.wait {
+		<-d.startReading
+		d.wait = false
+	}
 	if d.c.Count == 10 {
 		return av.Packet{}, io.EOF
 	}
@@ -87,6 +96,7 @@ func TestWriteBasicRTMP(t *testing.T) {
 	//Add a listener
 	l := &PacketsMuxer{}
 	stream.listeners["rand"] = l
+	stream.dirty = true
 	eof, err := stream.WriteRTMPToStream(context.Background(), &PacketsDemuxer{c: &Counter{Count: 0}})
 	if err != nil {
 		t.Error("Expecting nil, but got: ", err)
@@ -100,6 +110,53 @@ func TestWriteBasicRTMP(t *testing.T) {
 	time.Sleep(time.Millisecond * 100) //Sleep to make sure the last segment comes through
 	if l.numPackets() != 10 {
 		t.Errorf("Expecting packets length to be 10, but got: %v", l.numPackets())
+	}
+}
+
+func TestRTMPConcurrency(t *testing.T) {
+	// Tests adding and removing listeners from a source while mid-stream
+	// Run under -race
+
+	glog.Infof("\n\nTest%s\n", t.Name())
+	st := NewBasicRTMPVideoStream(t.Name())
+	demux := &PacketsDemuxer{c: &Counter{Count: 0}, wait: true, startReading: make(chan struct{})}
+	eof, err := st.WriteRTMPToStream(context.Background(), demux)
+	if err != nil {
+		t.Error("Error setting up test")
+	}
+	rng := rand.New(rand.NewSource(1234))
+	muxers := []*PacketsMuxer{}
+	for i := 0; i < 200; i++ {
+		close := rng.Int()%2 == 0
+		muxer := &PacketsMuxer{}
+		if i < 100 && !close {
+			// these muxers should receive all frames from demuxer because
+			// they start listening before packets arrive and aren't closed
+			muxers = append(muxers, muxer)
+		}
+		go func(close bool, p *PacketsMuxer) {
+			st.ReadRTMPFromStream(context.Background(), p)
+			if close {
+				p.Close()
+			}
+		}(close, muxer)
+		if i == 100 {
+			// start feeding in the middle of adding listeners
+			demux.startReading <- struct{}{}
+		}
+		time.Sleep(100 * time.Microsecond) // force thread to yield
+	}
+
+	<-eof // wait for eof
+
+	time.Sleep(time.Millisecond * 100) // ensure last segment comes through
+	if len(muxers) < 0 {
+		t.Error("Expected muxers to be nonzero") // sanity check
+	}
+	for i, m := range muxers {
+		if m.numPackets() != 10 {
+			t.Errorf("%d Expected packets length to be 10, but got %v", i, m.numPackets())
+		}
 	}
 }
 
@@ -202,6 +259,9 @@ func (d *PacketsMuxer) WriteTrailer() error {
 func (d *PacketsMuxer) WritePacket(pkt av.Packet) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.CalledClose {
+		return ErrMuxClosed
+	}
 	if d.packets == nil {
 		d.packets = make([]av.Packet, 0)
 	}


### PR DESCRIPTION
Fixes a number of issues identified by the golang race detector as brought up by @angyangie .

Ran unit tests via `go test -race` and the Livepeer goclient (although not with race).

Commits:

https://github.com/livepeer/lpms/commit/533c1cc3e091ca064b10a9d40b0e06cbba97c407 stream: Make RTMP stream tests threadsafe.

https://github.com/livepeer/lpms/commit/9c3a55568289da350e28fe0c346f552389b33857 stream: Make BasicRTMPVideoStream threadsafe.

https://github.com/livepeer/lpms/pull/118/commits/7740287b9a60a2952a4c2453882c28fd76ed3094 segmenter: Don't use default RTMP port for tests.
Hopefully it saves someone else from spending time debugging if
they forget there's a RTMP server also running on the machine.

https://github.com/livepeer/lpms/pull/118/commits/c371e7ad22863a5b0f072f6b69fc8d4f184ee717 vidlistener: Make tests threadsafe.