### PR TITLE
WIP: Configurable muxer options

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -271,11 +271,12 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
   }
 
   if (ictx->ac) {
-    codec = avcodec_find_encoder_by_name("aac"); // XXX make more flexible?
-    if (!codec) em_err("Unable to find aac\n");
+    codec = avcodec_find_encoder_by_name("aac");
+    //codec = avcodec_find_encoder_by_name(octx->aencoder);
+    if (!codec) em_err("Unable to find audio encoder\n");
     // open audio encoder
     ac = avcodec_alloc_context3(codec);
-    if (!ac) em_err("Unable to alloc audio encoder\n"); // XXX shld be optional
+    if (!ac) em_err("Unable to alloc audio encoder\n");
     octx->ac = ac;
     ac->sample_fmt = av_buffersink_get_format(octx->af.sink_ctx);
     ac->channel_layout = av_buffersink_get_channel_layout(octx->af.sink_ctx);

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -15,6 +15,8 @@ typedef struct {
   int w, h, bitrate;
   AVRational fps;
 
+  char *aencoder;
+
   char *muxer;
   AVDictionary *mux_opts;
 } output_params;

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -14,6 +14,9 @@ typedef struct {
   char *vfilters;
   int w, h, bitrate;
   AVRational fps;
+
+  char *muxer;
+  AVDictionary *mux_opts;
 } output_params;
 
 typedef struct {


### PR DESCRIPTION
Works nicely as-is, but not of much use until either of the following is true: 

* Additional container / format support becomes a product requirement (eg, fMP4 or DASH)
* Stream copy is fully implemented within the transcoder, which allows us to subsume the standalone segmenter with a combination of mux options + streamcopy. We need stream copy to copy audio anyway.

**Requires the GPU branch**