### PR TITLE
vidlistener: Support opaque user data.

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -27,6 +27,12 @@ import (
 
 var HLSWaitTime = time.Second * 10
 
+type exampleStream string
+
+func (t *exampleStream) StreamID() string {
+	return string(*t)
+}
+
 func randString(n int) string {
 	rand.Seed(time.Now().UnixNano())
 	x := make([]byte, n, n)
@@ -75,8 +81,9 @@ func main() {
 
 	lpms.HandleRTMPPublish(
 		//makeStreamID (give the stream an ID)
-		func(url *url.URL) (strmID string) {
-			return randString(10)
+		func(url *url.URL) stream.AppData {
+			s := exampleStream(randString(10))
+			return &s
 		},
 
 		//gotStream

--- a/core/lpms.go
+++ b/core/lpms.go
@@ -116,7 +116,7 @@ func (l *LPMS) Start(ctx context.Context) error {
 
 //HandleRTMPPublish offload to the video listener.  To understand how it works, look at videoListener.HandleRTMPPublish.
 func (l *LPMS) HandleRTMPPublish(
-	makeStreamID func(url *url.URL) (strmID string),
+	makeStreamID func(url *url.URL) (strmID stream.AppData),
 	gotStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error),
 	endStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error) {
 

--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -32,6 +32,7 @@ import (
 
 type TestStream struct{}
 
+func (s TestStream) AppData() stream.AppData              { return nil }
 func (s TestStream) String() string                       { return "" }
 func (s *TestStream) GetStreamFormat() stream.VideoFormat { return stream.RTMP }
 func (s *TestStream) GetStreamID() string                 { return "test" }

--- a/stream/basic_hls_videostream.go
+++ b/stream/basic_hls_videostream.go
@@ -53,6 +53,8 @@ func (s *BasicHLSVideoStream) SetSubscriber(f func(seg *HLSSegment, eof bool)) {
 //GetStreamID returns the streamID
 func (s *BasicHLSVideoStream) GetStreamID() string { return s.strmID }
 
+func (s *BasicHLSVideoStream) AppData() AppData { return nil }
+
 //GetStreamFormat always returns HLS
 func (s *BasicHLSVideoStream) GetStreamFormat() VideoFormat { return HLS }
 

--- a/stream/interface.go
+++ b/stream/interface.go
@@ -7,7 +7,12 @@ import (
 	"github.com/nareix/joy4/av"
 )
 
+type AppData interface {
+	StreamID() string
+}
+
 type VideoStream interface {
+	AppData() AppData
 	GetStreamID() string
 	GetStreamFormat() VideoFormat
 	String() string

--- a/vidlistener/listener.go
+++ b/vidlistener/listener.go
@@ -27,7 +27,7 @@ type VidListener struct {
 //gotStream is called when the stream starts.  It gives you access to the stream.
 //endStream is called when the stream ends.  It gives you access to the stream.
 func (self *VidListener) HandleRTMPPublish(
-	makeStreamID func(url *url.URL) (strmID string),
+	makeStreamID func(url *url.URL) (strmID stream.AppData),
 	gotStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error,
 	endStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error) {
 
@@ -36,7 +36,7 @@ func (self *VidListener) HandleRTMPPublish(
 			glog.V(2).Infof("RTMP server got upstream: %v", conn.URL)
 
 			strmID := makeStreamID(conn.URL)
-			if strmID == "" {
+			if strmID == nil || strmID.StreamID() == "" {
 				conn.Close()
 				return
 			}

--- a/vidlistener/listener_test.go
+++ b/vidlistener/listener_test.go
@@ -14,6 +14,16 @@ import (
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"
 )
 
+type testStream string
+
+func (t *testStream) StreamID() string {
+	return string(*t)
+}
+func newTestStream() *testStream {
+	t := testStream("testID")
+	return &t
+}
+
 func TestListener(t *testing.T) {
 	server := &joy4rtmp.Server{Addr: ":1937"}
 	listener := &VidListener{RtmpServer: server}
@@ -21,8 +31,8 @@ func TestListener(t *testing.T) {
 
 	listener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
-			return "testID"
+		func(url *url.URL) stream.AppData {
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
@@ -72,8 +82,8 @@ func TestListenerError(t *testing.T) {
 	failures := 0
 	badListener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
-			return "testID"
+		func(url *url.URL) stream.AppData {
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {
@@ -113,9 +123,9 @@ func TestListenerEmptyStreamID(t *testing.T) {
 
 	badListener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
+		func(url *url.URL) stream.AppData {
 			// On returning empty stream id connection should be closed
-			return ""
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {


### PR DESCRIPTION
This allows us to pass around per-stream data from MakeStreamID
without storing it outside LPMS.

In support of https://github.com/livepeer/go-livepeer/issues/793