### PR TITLE
Drain queued frames from the filter and encoder.

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -396,3 +396,58 @@ func TestNvidia_Devices(t *testing.T) {
 		t.Error(fmt.Errorf(fmt.Sprintf("\nError being: '%v'\n", err)))
 	}
 }
+
+func TestNvidia_DrainFilters(t *testing.T) {
+	// Going from low fps to high fps has the potential to retain lots of
+	// GPU surfaces. Ensure this is not a problem anymore.
+	// May be skipped in 'short' mode.
+
+	if testing.Short() {
+		t.Skip("Skipping encoding multiple profiles")
+	}
+
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+    set -eux
+    cd "$0"
+
+    # set up initial input; truncate test.ts file
+    ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
+  `
+	run(cmd)
+
+	prof := P240p30fps16x9
+	prof.Framerate = 100
+
+	fname := dir + "/test.ts"
+	oname := dir + "/out.ts"
+
+	// hw enc + dec
+	err := Transcode2(&TranscodeOptionsIn{
+		Fname: fname,
+		Accel: Nvidia,
+	}, []TranscodeOptions{
+		TranscodeOptions{
+			Oname:   oname,
+			Profile: prof,
+			Accel:   Nvidia,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmd = `
+    set -eux
+    cd "$0"
+
+    # ensure we have a 100fps output
+    ffprobe -loglevel warning -show_streams -select_streams v -count_frames out.ts > probe.out
+    grep nb_read_frames=100 probe.out
+    grep duration=1.00 probe.out
+  `
+	run(cmd)
+
+}

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -103,6 +103,8 @@ func TestNvidia_Transcoding(t *testing.T) {
 
 func TestNvidia_Pixfmts(t *testing.T) {
 
+	return // This test only seems to work with P100
+
 	run, dir := setupTest(t)
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
https://github.com/livepeer/lpms/commit/4e8c118536ac7cd69de174dfa3f653e5ef4974f6 : ffmpeg: Drain queued frames from the filter and encoder.  …
This allows for better resource management.

Multiple frames may be output for a given filter call, such as
upsampling the frame rate. This led to running out of
surfaces in GPU-encoding mode, and steadily increasing memory usage
in software-encoding mode.

Likewise, GOP structure may result in the encoder having several frames ready
to be returned after being fed earlier frames with no immediate result.

The transcode loop is reworked to:

0. Decode a frame
1. Feed the filter graph with the decoded frame
1a. Feed and drain the encoder if no filter graph is configured
2. Drain the filter graph as much as possible
3. Feed and drain the encoder for each frame received from the filter
4. Mux and output the resulting packets.

https://github.com/livepeer/lpms/commit/839b76208dc016f9095cad5e8c07168333eb3d44 : ffmpeg: Disable hardware-specific tests.  …
Seems to have worked on a P100 but breaks with a K80.

Disable for now until a more robust set of tests is in place.

Fixes https://github.com/livepeer/lpms/issues/127