### PR TITLE
move to go mod and `livepeer/joy4@livepeer`

### DIFF
--- a/core/lpms.go
+++ b/core/lpms.go
@@ -18,7 +18,7 @@ import (
 	"github.com/livepeer/lpms/vidplayer"
 	"github.com/livepeer/m3u8"
 
-	joy4rtmp "github.com/nareix/joy4/format/rtmp"
+	joy4rtmp "github.com/livepeer/joy4/format/rtmp"
 )
 
 var RetryCount = 3

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/livepeer/joy4 v0.1.0
+	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/m3u8 v0.6.1
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/livepeer/joy4 v0.1.0
 	github.com/livepeer/m3u8 v0.6.1
-	github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/livepeer/lpms
+
+go 1.12
+
+require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/livepeer/m3u8 v0.6.1
+	github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/livepeer/joy4 v0.1.0 h1:5DTF39KUDyGJER5vjwsWiDVxvPzgbalVJ9MgH8c6aqk=
-github.com/livepeer/joy4 v0.1.0/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
+github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
+github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/m3u8 v0.6.1 h1:vPOFZDnQIaNrNkYi0CVblg5HADuv7p/jTeI9SwWcw1s=
 github.com/livepeer/m3u8 v0.6.1/go.mod h1:l5UHxkeM4sE9xJhBdYs/WuUEdkoclOowGShhK7h3lBs=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/livepeer/m3u8 v0.6.1 h1:vPOFZDnQIaNrNkYi0CVblg5HADuv7p/jTeI9SwWcw1s=
+github.com/livepeer/m3u8 v0.6.1/go.mod h1:l5UHxkeM4sE9xJhBdYs/WuUEdkoclOowGShhK7h3lBs=
+github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431 h1:nWhrOsCKdV6bivw03k7MROF2tYzCFGfYBYFrTEHyucs=
+github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431/go.mod h1:aFJ1ZwLjvHN4yEzE5Bkz8rD8/d8Vlj3UIuvz2yfET7I=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/livepeer/joy4 v0.1.0 h1:5DTF39KUDyGJER5vjwsWiDVxvPzgbalVJ9MgH8c6aqk=
+github.com/livepeer/joy4 v0.1.0/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/m3u8 v0.6.1 h1:vPOFZDnQIaNrNkYi0CVblg5HADuv7p/jTeI9SwWcw1s=
 github.com/livepeer/m3u8 v0.6.1/go.mod h1:l5UHxkeM4sE9xJhBdYs/WuUEdkoclOowGShhK7h3lBs=
-github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431 h1:nWhrOsCKdV6bivw03k7MROF2tYzCFGfYBYFrTEHyucs=
-github.com/nareix/joy4 v0.0.0-20181022032202-3ddbc8f9d431/go.mod h1:aFJ1ZwLjvHN4yEzE5Bkz8rD8/d8Vlj3UIuvz2yfET7I=

--- a/segmenter/video_segmenter.go
+++ b/segmenter/video_segmenter.go
@@ -17,7 +17,7 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/m3u8"
-	"github.com/nareix/joy4/av"
+	"github.com/livepeer/joy4/av"
 )
 
 var ErrSegmenterTimeout = errors.New("SegmenterTimeout")

--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
 	"github.com/livepeer/m3u8"
-	"github.com/nareix/joy4/av"
-	"github.com/nareix/joy4/av/avutil"
-	"github.com/nareix/joy4/format"
-	"github.com/nareix/joy4/format/rtmp"
+	"github.com/livepeer/joy4/av"
+	"github.com/livepeer/joy4/av/avutil"
+	"github.com/livepeer/joy4/format"
+	"github.com/livepeer/joy4/format/rtmp"
 )
 
 type TestStream struct{}

--- a/stream/basic_rtmp_videostream.go
+++ b/stream/basic_rtmp_videostream.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/nareix/joy4/av"
+	"github.com/livepeer/joy4/av"
 )
 
 type BasicRTMPVideoStream struct {

--- a/stream/basic_rtmp_videostream_test.go
+++ b/stream/basic_rtmp_videostream_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/nareix/joy4/av"
-	"github.com/nareix/joy4/codec/h264parser"
+	"github.com/livepeer/joy4/av"
+	"github.com/livepeer/joy4/codec/h264parser"
 )
 
 //Testing WriteRTMP errors

--- a/stream/interface.go
+++ b/stream/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/livepeer/m3u8"
-	"github.com/nareix/joy4/av"
+	"github.com/livepeer/joy4/av"
 )
 
 type AppData interface {

--- a/vidlistener/listener.go
+++ b/vidlistener/listener.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
-	joy4rtmp "github.com/nareix/joy4/format/rtmp"
+	joy4rtmp "github.com/livepeer/joy4/format/rtmp"
 )
 
 var segOptions = segmenter.SegmenterOptions{SegLength: time.Second * 2}

--- a/vidlistener/listener_test.go
+++ b/vidlistener/listener_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/livepeer/lpms/stream"
-	"github.com/nareix/joy4/av/pubsub"
-	joy4rtmp "github.com/nareix/joy4/format/rtmp"
+	"github.com/livepeer/joy4/av/pubsub"
+	joy4rtmp "github.com/livepeer/joy4/format/rtmp"
 )
 
 type testStream string

--- a/vidplayer/player.go
+++ b/vidplayer/player.go
@@ -19,7 +19,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/m3u8"
-	joy4rtmp "github.com/nareix/joy4/format/rtmp"
+	joy4rtmp "github.com/livepeer/joy4/format/rtmp"
 )
 
 var ErrNotFound = errors.New("ErrNotFound")

--- a/vidplayer/player_test.go
+++ b/vidplayer/player_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/m3u8"
-	joy4rtmp "github.com/nareix/joy4/format/rtmp"
+	joy4rtmp "github.com/livepeer/joy4/format/rtmp"
 )
 
 func TestRTMP(t *testing.T) {


### PR DESCRIPTION
This PR sets us up for managing `go-livepeer` dependencies using `go mod`.

Users building standalone lpms using `GOPATH` will still have to manually run `go get github.com/livepeer/joy4@livepeer` - This PR should at least get them a step closer by pointing them to the correct repository.

Users building standalone lpms using `go mod` should be automatically pointed to the correct revision of joy4.

Users building `go-livepeer` must continue building using the vendored lpms and `GOPATH` until `go mod` is completely ready.

This does nothing to harm to current state of things for users with today's build methods.