### PR TITLE
fix cmd/example/main.go: Infof call has arguments but no formatting directives

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -179,7 +179,7 @@ func main() {
 	lpms.HandleRTMPPlay(
 		//getStream
 		func(url *url.URL) (stream.RTMPVideoStream, error) {
-			glog.Infof("Got req: ", url.Path)
+			glog.Infof("Got req: %v", url.Path)
 			if rtmpStrm != nil {
 				strmID := parseStreamID(url.Path)
 				if strmID == rtmpStrm.GetStreamID() {


### PR DESCRIPTION
```
# github.com/livepeer/lpms/cmd/example
cmd/example/main.go:182:14: Infof call has arguments but no formatting directives
```