### PR TITLE
Count decoded pixels.

### DIFF
--- a/cmd/transcoding/transcoding.go
+++ b/cmd/transcoding/transcoding.go
@@ -75,7 +75,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	for i, r := range res {
+	fmt.Printf("profile=input frames=%v pixels=%v\n", res.Decoded.Frames, res.Decoded.Pixels)
+	for i, r := range res.Encoded {
 		fmt.Printf("profile=%v frames=%v pixels=%v\n", profiles[i].Name, r.Frames, r.Pixels)
 	}
 }

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -137,9 +137,6 @@ func Transcode3(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeRes
 	if input == nil {
 		return nil, ErrTranscoderInp
 	}
-	if len(ps) <= 0 {
-		return nil, nil
-	}
 	hw_type, err := accelDeviceType(input.Accel)
 	if err != nil {
 		return nil, err
@@ -188,7 +185,15 @@ func Transcode3(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeRes
 	inp := &C.input_params{fname: fname, hw_type: hw_type, device: device}
 	results := make([]C.output_results, len(ps))
 	decoded := &C.output_results{}
-	ret := int(C.lpms_transcode(inp, (*C.output_params)(&params[0]), (*C.output_results)(&results[0]), C.int(len(params)), decoded))
+	var (
+		paramsPointer  *C.output_params
+		resultsPointer *C.output_results
+	)
+	if len(params) > 0 {
+		paramsPointer = (*C.output_params)(&params[0])
+		resultsPointer = (*C.output_results)(&results[0])
+	}
+	ret := int(C.lpms_transcode(inp, paramsPointer, resultsPointer, C.int(len(params)), decoded))
 	if 0 != ret {
 		glog.Infof("Transcoder Return : %v\n", Strerror(ret))
 		return nil, ErrorMap[ret]

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -411,11 +411,10 @@ func TestTranscoderStatistics_Decoded(t *testing.T) {
 		info := res.Encoded[0]
 
 		// Now attempt to re-encode the transcoded data
+		// Pass in an empty output to achieve a decode-only flow
 		// and check decoded results from *that*
-		p.Framerate = 10
 		in = &TranscodeOptionsIn{Fname: oname}
-		out = []TranscodeOptions{TranscodeOptions{Profile: p, Oname: "out.ts"}}
-		res, err = Transcode3(in, out)
+		res, err = Transcode3(in, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -452,9 +451,7 @@ func TestTranscoderStatistics_Decoded(t *testing.T) {
     `
 	run(cmd)
 	in := &TranscodeOptionsIn{Fname: dir + "/combined.ts"}
-	out := []TranscodeOptions{TranscodeOptions{Profile: P240p30fps16x9, Oname: "out.ts"}}
-
-	res, err := Transcode3(in, out)
+	res, err := Transcode3(in, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -759,7 +759,7 @@ proc_cleanup:
 #define MAX_OUTPUT_SIZE 10
 
 int lpms_transcode(input_params *inp, output_params *params,
-    output_results *results, int nb_outputs)
+    output_results *results, int nb_outputs, output_results *decoded_results)
 {
 #define main_err(msg) { \
   if (!ret) ret = AVERROR(EINVAL); \
@@ -820,6 +820,11 @@ int lpms_transcode(input_params *inp, output_params *params,
                             // Bail out on streams that appear to be broken
     else if (ret < 0) main_err("transcoder: Could not decode; stopping\n");
     ist = ictx.ic->streams[ipkt.stream_index];
+
+    if (AVMEDIA_TYPE_VIDEO == ist->codecpar->codec_type) {
+      decoded_results->frames++;
+      decoded_results->pixels += dframe->width * dframe->height;
+    }
 
     for (i = 0; i < nb_outputs; i++) {
       struct output_ctx *octx = &outputs[i];

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -31,6 +31,6 @@ typedef struct {
 
 void lpms_init();
 int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char *seg_start);
-int  lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs);
+int  lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
 
 #endif // _LPMS_FFMPEG_H_


### PR DESCRIPTION
* Adds support for counting decoded pixels
* Allows passing in empty output parameters to force a decode-only flow.

The GetMediaInfo function in go-livepeer becomes:

```golang
func GetMediaInfo(fname string) (*MediaInfo, error) {
       in := &TranscodeOptionsIn{Fname: fname}
       res, err := Transcode3(in, nil)
       if err != nil {
               return nil, err
       }
       return &res.Decoded, nil
}
```

This could be further specialized to return pixels only, rather than a generic struct, because go-livepeer not likely to need the frame count.

Fixes https://github.com/livepeer/lpms/issues/125
