### PR TITLE
Add stream copy and dropping.

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -172,12 +172,16 @@ func Transcode3(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeRes
 		param := p.Profile
 		w, h, err := VideoProfileResolution(param)
 		if err != nil {
-			return nil, err
+			if "drop" != p.VideoEncoder.Name && "copy" != p.VideoEncoder.Name {
+				return nil, err
+			}
 		}
 		br := strings.Replace(param.Bitrate, "k", "000", 1)
 		bitrate, err := strconv.Atoi(br)
 		if err != nil {
-			return nil, err
+			if "drop" != p.VideoEncoder.Name && "copy" != p.VideoEncoder.Name {
+				return nil, err
+			}
 		}
 		encoder, scale_filter := p.VideoEncoder.Name, "scale"
 		if encoder == "" {

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -575,3 +575,122 @@ func TestTranscoder_StatisticsAspectRatio(t *testing.T) {
 		t.Error(fmt.Errorf("Results did not match: %v ", r))
 	}
 }
+
+func TestTranscoder_MuxerOpts(t *testing.T) {
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	// Prepare test environment : truncate input file
+	cmd := `
+        set -eux
+        cd $0
+
+        cp "$1/../transcoder/test.ts" inp.ts
+        ffmpeg -i inp.ts -c:a copy -c:v copy -t 1 inp-short.ts
+    `
+	run(cmd)
+
+	prof := P240p30fps16x9
+
+	// Set the muxer itself given a different extension
+	_, err := Transcode3(&TranscodeOptionsIn{
+		Fname: dir + "/inp-short.ts",
+	}, []TranscodeOptions{TranscodeOptions{
+		Oname:   dir + "/out-mkv.mp4",
+		Profile: prof,
+		Muxer:   ComponentOptions{Name: "matroska"},
+	}})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Pass in some options to muxer
+	_, err = Transcode3(&TranscodeOptionsIn{
+		Fname: dir + "/inp.ts",
+	}, []TranscodeOptions{TranscodeOptions{
+		Oname:   dir + "/out.mpd",
+		Profile: prof,
+		Muxer: ComponentOptions{
+			Name: "dash",
+			Opts: map[string]string{
+				"media_seg_name": "lpms-test-$RepresentationID$-$Number%05d$.m4s",
+				"init_seg_name":  "lpms-init-$RepresentationID$.m4s",
+			},
+		},
+	}})
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmd = `
+        set -eux
+        cd $0
+
+        # check formats and that options were used
+        ffprobe -loglevel warning -show_format out-mkv.mp4 | grep format_name=matroska
+        # ffprobe -loglevel warning -show_format out.mpd | grep format_name=dash # this fails so skip for now
+
+        # concat headers. mp4 chunks are annoying
+        cat lpms-init-0.m4s lpms-test-0-00001.m4s > video.m4s
+        cat lpms-init-1.m4s lpms-test-1-00001.m4s > audio.m4s
+        ffprobe -show_format video.m4s | grep nb_streams=1
+        ffprobe -show_format audio.m4s | grep nb_streams=1
+        ffprobe -show_streams -select_streams v video.m4s | grep codec_name=h264
+        ffprobe -show_streams -select_streams a audio.m4s | grep codec_name=aac
+    `
+	run(cmd)
+}
+
+func TestTranscoder_EncoderOpts(t *testing.T) {
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	// Prepare test environment : truncate input file
+	cmd := `
+        set -eux
+        cd $0
+
+        # truncate input
+        ffmpeg -i "$1/../transcoder/test.ts" -c:a copy -c:v copy -t 1 test.ts
+
+        # we will sanity check image quality with ssim
+        # since ssim needs res and framecount to match, sanity check those
+        ffprobe -show_streams -select_streams v test.ts | grep width=1280
+        ffprobe -show_streams -select_streams v test.ts | grep height=720
+        ffprobe -count_frames -show_streams -select_streams v test.ts | grep nb_read_frames=60
+    `
+	run(cmd)
+
+	prof := P720p60fps16x9
+	in := &TranscodeOptionsIn{Fname: dir + "/test.ts"}
+	out := []TranscodeOptions{TranscodeOptions{
+		Oname:        dir + "/out.nut",
+		Profile:      prof,
+		VideoEncoder: ComponentOptions{Name: "snow"},
+		AudioEncoder: ComponentOptions{
+			Name: "vorbis",
+			// required since vorbis implementation is marked experimental
+			// also, gives us an opportunity to test the audio opts
+			Opts: map[string]string{"strict": "experimental"}},
+	}}
+	_, err := Transcode3(in, out)
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmd = `
+        set -eux
+        cd $0
+
+        # Check codecs are what we expect them to be
+        ffprobe -show_streams -select_streams v out.nut | grep codec_name=snow
+        ffprobe -show_streams -select_streams a out.nut | grep codec_name=vorbis
+
+        # sanity check image quality : compare using ssim
+        ffmpeg -loglevel warning -i out.nut -i test.ts -lavfi '[0:v][1:v]ssim=stats.log' -f null -
+        # ensure that no more than 5 frames have ssim < 0.95
+        grep -Po 'All:\K\d+.\d+' stats.log | awk '{ if ($1 < 0.95) count=count+1 } END{ exit count > 5 }'
+    `
+	run(cmd)
+}

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -248,14 +248,6 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
     }
     vc->pix_fmt = av_buffersink_get_format(octx->vf.sink_ctx); // XXX select based on encoder + input support
     if (fmt->flags & AVFMT_GLOBALHEADER) vc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-    /*
-    if (ictx->vc->extradata) {
-      // XXX only if transmuxing!
-      vc->extradata = av_mallocz(ictx->vc->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
-      if (!vc->extradata) em_err("Unable to allocate video extradata\n");
-      memcpy(vc->extradata, ictx->vc->extradata, ictx->vc->extradata_size);
-      vc->extradata_size = ictx->vc->extradata_size;
-    }*/
     ret = avcodec_open2(vc, codec, NULL);
     if (ret < 0) em_err("Error opening video encoder\n");
 

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -9,11 +9,20 @@ extern const int lpms_ERR_INPUT_PIXFMT;
 extern const int lpms_ERR_FILTERS;
 
 typedef struct {
+    char *name;
+    AVDictionary *opts;
+} component_opts;
+
+typedef struct {
   char *fname;
-  char *vencoder;
   char *vfilters;
   int w, h, bitrate;
   AVRational fps;
+
+  component_opts muxer;
+  component_opts audio;
+  component_opts video;
+
 } output_params;
 
 typedef struct {


### PR DESCRIPTION
Still needs checking for memory leaks, but opening this for review to get feedback.

This patch set modifies the `TranscodeOptions` struct to take options for the video encoder, audio encoder and muxer.  These options take a common `ComponentOpts` struct which specifies a name, and a set of options that correspond directly to the FFmpeg AVOptions for the component. Using these AVOptions should allow us to remove hardcoded and ad-hoc configuration options.  See "Follow Ups" for more details.

On top of the ComponentOpts, special-case handling is added for stream copy and stream dropping.

 This PR is backwards compatible with the existing Transcode3 API. If the audio/video options are omitted, the original behavior is preserved: x264 and AAC are encoded (or nvenc if hardware acceleration is specified).

### Examples

To copy an audio stream: `TranscodeOptions{ AudioEncoder: ComponentOptions{ Name: "copy" }}`

To discard a video stream: `TranscodeOptions{ VideoEncoder: ComponentOptions{ Name: "drop"}}`

To generate a md5 hash of the audio stream only:
```
TranscodeOptions{
  Oname: "audio.md5",
  AudioEncoder: ComponentOptions{ Name: "copy" },
  VideoEncoder: ComponentOptions{ Name: "drop" },
  Muxer: ComponentOptions{ Name: "md5" },
}
```

### Commits

https://github.com/livepeer/lpms/pull/150/commits/755f4b54c255379828f2213ab70753ef7aab5e1f : ffmpeg: Remove unused extradata copy code.

https://github.com/livepeer/lpms/pull/150/commits/a34627dfcddfabfd67e502ea0711c0442687682c : ffmpeg: Use AVOptions for muxer and A/V encoders.

https://github.com/livepeer/lpms/pull/150/commits/54db6b907b617d75e94c71e65f491b2284367a6f : ffmpeg: Add stream copy and drop.

### TODO before merging

- [x] Additional test cases as noted within code
- [ ] Valgrind/asan memory checking

### Fixes

Fixes https://github.com/livepeer/lpms/issues/148
Fixes https://github.com/livepeer/lpms/issues/55
Fixes https://github.com/livepeer/lpms/issues/54

### Follow Ups

Currently, the `Opts` part of the ComponentOptions is not used outside of test cases. Nearly all of our encoder configuration can be specified via AVOptions, however there is currently a dependency ordering issue: AVFilters are typically initialized prior to encoders, and the encoders take their configuration from the filters. Swapping the order of initialization should allow us to make use of AVOptions and minimize the use of ad-hoc, hard coded options as exhibited below:

https://github.com/livepeer/lpms/blob/f1b88b60503b33a74deebefadc7419fe8f49d146/ffmpeg/lpms_ffmpeg.c#L240-L244

https://github.com/livepeer/lpms/blob/f1b88b60503b33a74deebefadc7419fe8f49d146/ffmpeg/lpms_ffmpeg.c#L279-L283

https://github.com/livepeer/lpms/blob/f1b88b60503b33a74deebefadc7419fe8f49d146/ffmpeg/lpms_ffmpeg.h#L11-L17

### Notes

These ComponentOptions are passed in directly to FFmpeg, with all the flexibility and risk that entails. As such, library users (eg, go-livepeer) should take care to to ensure the options are used a safe manner, especially if exposed to arbitrary user input.