### PR TITLE
WIP: Stream copy segmenter

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -61,6 +61,20 @@ type TranscodeResults struct {
 }
 
 func RTMPToHLS(localRTMPUrl string, outM3U8 string, tmpl string, seglen_secs string, seg_start int) error {
+	//glog.Errorf("Segmentating %s - %s - template %s", localRTMPUrl, outM3U8, tmpl)
+	in := &TranscodeOptionsIn{Fname: localRTMPUrl}
+	out := []TranscodeOptions{TranscodeOptions{
+		Oname:        outM3U8,
+		VideoEncoder: ComponentOpts{Name: "copy"},
+		AudioEncoder: ComponentOpts{Name: "copy"},
+		Muxer: ComponentOpts{Name: "hls", Opts: map[string]string{
+			"hls_time":             seglen_secs,
+			"hls_segment_filename": tmpl,
+			"start_number":         fmt.Sprintf("%d", seg_start),
+			"hls_flags":            "delete_segments",
+		}}}}
+	_, err := Transcode3(in, out)
+	return err
 	inp := C.CString(localRTMPUrl)
 	outp := C.CString(outM3U8)
 	ts_tmpl := C.CString(tmpl)


### PR DESCRIPTION
Posting this PR here in case we need to pick it up someday.

This PR implements the segmenter by invoking the transcoder with stream copy and the corresponding HLS muxer options. Doing it this way allows a few things:

- Supports video-only or audio-only streams in segmenter. Fixes https://github.com/livepeer/lpms/issues/60

- Removes segmenter-specific FFmpeg code: `lpms_rtmp2hls` C function can be removed entirely, and `RTMPToHLS` [1] can be simplified to a single Transcode call.

[1] It should be noted that the `RTMPToHLS` function in particular is poorly named, since the input can come from anywhere, not just RTMP.

### TODO Before Merging

Some small changes are required to make the tests pass:

- [ ] Needs to drop late packets. Failing test `TestSegmenter_DropLatePackets`

https://github.com/livepeer/lpms/blob/f1b88b60503b33a74deebefadc7419fe8f49d146/ffmpeg/lpms_ffmpeg.c#L135

- [ ] Needs to drop leading frames up to a keyframe. Failing test `TestMissingKeyframe`

https://github.com/livepeer/lpms/blob/f1b88b60503b33a74deebefadc7419fe8f49d146/ffmpeg/lpms_ffmpeg.c#L130-L133