### PR TITLE
Update joy4 and ffmpeg.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/livepeer/lpms
     docker:
-      - image: "circleci/golang:1.11.5"
+      - image: "circleci/golang:1.13.4"
         environment:
           GOROOT: /usr/local/go
           PKG_CONFIG_PATH: "/home/circleci/compiled/lib/pkgconfig"
@@ -23,7 +23,7 @@ jobs:
           name: "Build FFMpeg"
           command: |
             sudo apt-get update
-            sudo apt-get install -y autoconf build-essential pkg-config autoconf gnutls-dev
+            sudo apt-get install -y autoconf build-essential pkg-config autoconf gnutls-dev zlib1g-dev netcat-openbsd
             bash ./install_ffmpeg.sh
 
       - save_cache:

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1018,20 +1018,6 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
     `
 	run(cmd)
 
-	// Test failure of audio copy in mpegts-to-(not-mp4). eg, flv
-	// Fixing this requires using the aac_adtstoasc bitstream filter.
-	// (mp4 muxer automatically inserts it if necessary; others don't)
-	in.Fname = "../transcoder/test.ts"
-	out = []TranscodeOptions{TranscodeOptions{
-		Oname:        dir + "/fail.flv",
-		VideoEncoder: ComponentOptions{Name: "drop"},
-		AudioEncoder: ComponentOptions{Name: "copy"},
-	}}
-	_, err = Transcode3(in, out)
-	if err == nil || err.Error() != "Invalid data found when processing input" {
-		t.Error("Expected error converting audio from ts to flv but got ", err)
-	}
-
 	// Encode one stream of a short sample while copying / dropping another
 	in.Fname = dir + "/test-short.ts"
 	out = []TranscodeOptions{TranscodeOptions{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/livepeer/joy4 v0.1.1
+	github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded
 	github.com/livepeer/m3u8 v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
-github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
+github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=
+github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/m3u8 v0.11.0 h1:aI2hLXV5h5VqxjjmAOs55TpUR35KzNL2XWLkbETql5g=
 github.com/livepeer/m3u8 v0.11.0/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -24,7 +24,7 @@ if [ ! -e "$HOME/x264/x264" ]; then
 fi
 
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
-  git clone -b n4.1 https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
+  git clone -b livepeer-2019_11_19 https://github.com/livepeer/FFmpeg "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
   ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gnutls --enable-gpl --enable-static
   make

--- a/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/transcoder/ffmpeg_segment_transcoder_test.go
@@ -37,12 +37,12 @@ func TestTrans(t *testing.T) {
 		t.Errorf("Expecting 2 output segments, got %v", len(r))
 	}
 
-	if len(r[0]) < 250000 || len(r[0]) > 280000 {
-		t.Errorf("Expecting output size to be between 250000 and 280000 , got %v", len(r[0]))
+	if len(r[0]) < 250000 || len(r[0]) > 285000 {
+		t.Errorf("Expecting output size to be between 250000 and 285000 , got %v", len(r[0]))
 	}
 
-	if len(r[1]) < 280000 || len(r[1]) > 310000 {
-		t.Errorf("Expecting output size to be between 280000 and 310000 , got %v", len(r[1]))
+	if len(r[1]) < 280000 || len(r[1]) > 314000 {
+		t.Errorf("Expecting output size to be between 280000 and 314000 , got %v", len(r[1]))
 	}
 
 	if len(r[2]) < 600000 || len(r[2]) > 700000 {


### PR DESCRIPTION
Splitting up some of https://github.com/livepeer/lpms/pull/141 into this PR in order to make the changes a touch less overwhelming.

* Updates FFmpeg to use the Livepeer forked branch at https://github.com/livepeer/ffmpeg
* Updates joy4 to fix some breakage resulting from the ffmpeg update. Specifically, this [change](http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=ce1fcc8cede2971f6e36119e9dd41fb41b36c63a) modified the general libav code to *not* treat general IO errors as EOF. This broke some tests with the segmenter. Drilling down on the problem revealed that ffmpeg has a stricter view of what constitutes a proper EOF for RTMP : the playback stream needs to be torn down completely. Turns out that joy4 was simply terminating the connection, rather than tearing down the stream following the RTMP protocol. The teardown is added to joy4 here: https://github.com/livepeer/joy4/pull/6/commits/b2fea45cbded689f3235d48fdb28ce58518e6fce
* Fix some other test breakage induced by the ffmpeg update. In particular:

  * ADTS to ASC bitstream filters are now automatically inserted for the FLV muxer, so going from mpegts to FLV doesn't break anymore. Couldn't find another case which exhibits the same type of breakage, so just removed the test. (Almost everything else that holds AAC metadata in "Audio Specific Config" ASC format is a MP4 variant, and more exotic formats like nut can take basically anything.)

  * Some encoded file sizes got slightly larger. Haven't looked into precisely what / why but doesn't seem like an issue.

  * Tightened up the testing around draining GPU filter graphs. Something about the underlying implementation changed and is giving us 2 extra frames now. Sanity checked this against the results produced by the ffmpeg CLI itself: they match.

  * We have better test for RTMP stream disconnect. The old test broke since the stream is terminated cleanly now, even if no media packets are sent. We work around this by setting up a "server" with `nc` and sending a bogus RTMP handshake to which throws an IO error from ffmpeg. This isn't *strictly* a network disconnect, but is close enough.