### PR TITLE
ffmpeg: Pass through FPS.

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -191,7 +191,11 @@ func Transcode3(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeRes
 			}
 		}
 		// preserve aspect ratio along the larger dimension when rescaling
-		filters := fmt.Sprintf("fps=%d/%d,%s='w=if(gte(iw,ih),%d,-2):h=if(lt(iw,ih),%d,-2)'", param.Framerate, 1, scale_filter, w, h)
+		var filters string
+		if param.Framerate > 0 {
+			filters = fmt.Sprintf("fps=%d/1,", param.Framerate)
+		}
+		filters += fmt.Sprintf("%s='w=if(gte(iw,ih),%d,-2):h=if(lt(iw,ih),%d,-2)'", scale_filter, w, h)
 		if input.Accel != Software && p.Accel == Software {
 			// needed for hw dec -> hw rescale -> sw enc
 			filters = filters + ":format=yuv420p,hwdownload"
@@ -219,7 +223,10 @@ func Transcode3(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeRes
 		defer C.free(unsafe.Pointer(vidOpts.name))
 		defer C.free(unsafe.Pointer(audioOpts.name))
 		defer C.free(unsafe.Pointer(vfilt))
-		fps := C.AVRational{num: C.int(param.Framerate), den: 1}
+		var fps C.AVRational
+		if param.Framerate > 0 {
+			fps = C.AVRational{num: C.int(param.Framerate), den: 1}
+		}
 		params[i] = C.output_params{fname: oname, fps: fps,
 			w: C.int(w), h: C.int(h), bitrate: C.int(bitrate),
 			muxer: muxOpts, audio: audioOpts, video: vidOpts, vfilters: vfilt}

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -265,7 +265,10 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
     vc->width = av_buffersink_get_w(octx->vf.sink_ctx);
     vc->height = av_buffersink_get_h(octx->vf.sink_ctx);
     if (octx->fps.den) vc->framerate = av_buffersink_get_frame_rate(octx->vf.sink_ctx);
+    else vc->framerate = ictx->vc->framerate;
     if (octx->fps.den) vc->time_base = av_buffersink_get_time_base(octx->vf.sink_ctx);
+    else if (ictx->vc->time_base.num && ictx->vc->time_base.den) vc->time_base = ictx->vc->time_base;
+    else vc->time_base = ictx->ic->streams[ictx->vi]->time_base;
     if (octx->bitrate) vc->rc_min_rate = vc->rc_max_rate = vc->rc_buffer_size = octx->bitrate;
     if (av_buffersink_get_hw_frames_ctx(octx->vf.sink_ctx)) {
       vc->hw_frames_ctx =


### PR DESCRIPTION
- https://github.com/livepeer/lpms/commit/a92aab19541fc2a06c1c6aa3a4c6cca398a425a6 : ffmpeg: Support frame rate passthrough.

- https://github.com/livepeer/lpms/commit/b20b031c36402da7863f52957067bbcf3bed8a7e : segmenter: Loosen up options used with nc.
Makes things a bit more portable.

Fixes https://github.com/livepeer/go-livepeer/issues/1239