### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Do the following steps to view a live stream video:
 
 2. Upload an RTMP video stream to `rtmp://localhost:1935/stream/test`.  We recommend using ffmpeg or [OBS](https://obsproject.com/download).
 
-For ffmpeg on osx, run: `ffmpeg -f avfoundation -framerate 30 -pixel_format uyvy422 -i "0:0" -vcodec libx264 -tune zerolatency -b 900k -x264-params keyint=60:min-keyint=60 -f flv rtmp://localhost:1935/stream/test`
+For ffmpeg on osx, run: `ffmpeg -f avfoundation -framerate 30 -pixel_format uyvy422 -i "0:0" -c:v libx264 -tune zerolatency -b:v 900k -x264-params keyint=60:min-keyint=60 -c:a aac -ac 2 -ar 44100 -f flv rtmp://localhost:1935/stream/test`
 
 For OBS, fill in Settings->Stream->URL to be rtmp://localhost:1935
 

--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -10,7 +10,7 @@ func TestTranscoderAPI_InvalidFile(t *testing.T) {
 	tc := NewTranscoder()
 	defer tc.StopTranscoder()
 	in := &TranscodeOptionsIn{}
-	out := []TranscodeOptions{TranscodeOptions{
+	out := []TranscodeOptions{{
 		Oname:        "-",
 		AudioEncoder: ComponentOptions{Name: "copy"},
 		VideoEncoder: ComponentOptions{Name: "drop"},
@@ -78,7 +78,7 @@ func TestTranscoderAPI_Stopped(t *testing.T) {
 func TestTranscoderAPI_TooManyOutputs(t *testing.T) {
 
 	out := make([]TranscodeOptions, 11)
-	for i, _ := range out {
+	for i := range out {
 		out[i].VideoEncoder = ComponentOptions{Name: "drop"}
 	}
 	in := &TranscodeOptionsIn{}

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -403,7 +403,7 @@ func TestTranscoderStatistics_Decoded(t *testing.T) {
 	// Ensure decoded re-transcode stats match original transcoded statistics
 	for i, p := range profiles {
 		oname := fmt.Sprintf("%s/out_%d.ts", dir, i)
-		out := []TranscodeOptions{TranscodeOptions{Profile: p, Oname: oname}}
+		out := []TranscodeOptions{{Profile: p, Oname: oname}}
 		in := &TranscodeOptionsIn{Fname: fmt.Sprintf("%s/test_%d.ts", dir, i)}
 		res, err := Transcode3(in, out)
 		if err != nil {
@@ -576,7 +576,7 @@ func TestTranscoder_StatisticsAspectRatio(t *testing.T) {
 
 	// This will be adjusted to 124x70 by the rescaler (since source is 16:9)
 	pAdj := VideoProfile{Resolution: "124x456", Framerate: 16, Bitrate: "100k"}
-	out := []TranscodeOptions{TranscodeOptions{Profile: pAdj, Oname: dir + "/adj.mp4"}}
+	out := []TranscodeOptions{{Profile: pAdj, Oname: dir + "/adj.mp4"}}
 	res, err := Transcode3(&TranscodeOptionsIn{Fname: dir + "/test.ts"}, out)
 	if err != nil || len(res.Encoded) <= 0 {
 		t.Error(err)
@@ -606,7 +606,7 @@ func TestTranscoder_MuxerOpts(t *testing.T) {
 	// Set the muxer itself given a different extension
 	_, err := Transcode3(&TranscodeOptionsIn{
 		Fname: dir + "/inp-short.ts",
-	}, []TranscodeOptions{TranscodeOptions{
+	}, []TranscodeOptions{{
 		Oname:   dir + "/out-mkv.mp4",
 		Profile: prof,
 		Muxer:   ComponentOptions{Name: "matroska"},
@@ -619,7 +619,7 @@ func TestTranscoder_MuxerOpts(t *testing.T) {
 	// Pass in some options to muxer
 	_, err = Transcode3(&TranscodeOptionsIn{
 		Fname: dir + "/inp.ts",
-	}, []TranscodeOptions{TranscodeOptions{
+	}, []TranscodeOptions{{
 		Oname:   dir + "/out.mpd",
 		Profile: prof,
 		Muxer: ComponentOptions{
@@ -675,7 +675,7 @@ func TestTranscoder_EncoderOpts(t *testing.T) {
 
 	prof := P720p60fps16x9
 	in := &TranscodeOptionsIn{Fname: dir + "/test.ts"}
-	out := []TranscodeOptions{TranscodeOptions{
+	out := []TranscodeOptions{{
 		Oname:        dir + "/out.nut",
 		Profile:      prof,
 		VideoEncoder: ComponentOptions{Name: "snow"},
@@ -725,12 +725,12 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 	// Test normal stream-copy case
 	in := &TranscodeOptionsIn{Fname: dir + "/test-short.ts"}
 	out := []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:        dir + "/audiocopy.ts",
 			Profile:      P144p30fps16x9,
 			AudioEncoder: ComponentOptions{Name: "copy"},
 		},
-		TranscodeOptions{
+		{
 			Oname: dir + "/videocopy.ts",
 			VideoEncoder: ComponentOptions{Name: "copy", Opts: map[string]string{
 				"mpegts_flags": "resend_headers,initial_discontinuity",
@@ -775,7 +775,7 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 	run(cmd)
 	in = &TranscodeOptionsIn{Fname: dir + "/videoonly.ts"}
 	out = []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:        dir + "/novideo.ts",
 			VideoEncoder: ComponentOptions{Name: "copy"},
 		},
@@ -789,7 +789,7 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 	}
 	in = &TranscodeOptionsIn{Fname: dir + "/audioonly.ts"}
 	out = []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:        dir + "/noaudio.ts",
 			Profile:      P144p30fps16x9,
 			AudioEncoder: ComponentOptions{Name: "copy"},
@@ -824,8 +824,8 @@ func TestTranscoder_StreamCopy_Validate_B_Frames(t *testing.T) {
 	// Test normal stream-copy case
 	in := &TranscodeOptionsIn{Fname: dir + "/test-short.ts"}
 	out := []TranscodeOptions{
-		TranscodeOptions{
-			Oname: dir + "/videocopy.ts",
+		{
+			Oname:        dir + "/videocopy.ts",
 			VideoEncoder: ComponentOptions{Name: "copy"},
 		},
 	}
@@ -872,7 +872,7 @@ func TestTranscoder_Drop(t *testing.T) {
 	// Normal case : drop only video
 	in := &TranscodeOptionsIn{Fname: dir + "/test-short.ts"}
 	out := []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:        dir + "/novideo.ts",
 			VideoEncoder: ComponentOptions{Name: "drop"},
 		},
@@ -887,7 +887,7 @@ func TestTranscoder_Drop(t *testing.T) {
 
 	// Normal case: drop only audio
 	out = []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:        dir + "/noaudio.ts",
 			AudioEncoder: ComponentOptions{Name: "drop"},
 			Profile:      P144p30fps16x9,
@@ -902,7 +902,7 @@ func TestTranscoder_Drop(t *testing.T) {
 	}
 
 	// Test error when trying to mux no streams
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/none.mp4",
 		VideoEncoder: ComponentOptions{Name: "drop"},
 		AudioEncoder: ComponentOptions{Name: "drop"},
@@ -913,7 +913,7 @@ func TestTranscoder_Drop(t *testing.T) {
 	}
 
 	// Test error when missing profile in default video configuration
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/profile.mp4",
 		AudioEncoder: ComponentOptions{Name: "drop"},
 	}}
@@ -924,7 +924,7 @@ func TestTranscoder_Drop(t *testing.T) {
 
 	// Sanity check default transcode options with single-stream input
 	in.Fname = dir + "/noaudio.ts"
-	out = []TranscodeOptions{TranscodeOptions{Oname: dir + "/encoded-video.mp4", Profile: P144p30fps16x9}}
+	out = []TranscodeOptions{{Oname: dir + "/encoded-video.mp4", Profile: P144p30fps16x9}}
 	res, err = Transcode3(in, out)
 	if err != nil {
 		t.Error(err)
@@ -933,7 +933,7 @@ func TestTranscoder_Drop(t *testing.T) {
 		t.Error("Unexpected encoded/decoded frame counts ", res.Decoded.Frames, res.Encoded[0].Frames)
 	}
 	in.Fname = dir + "/novideo.ts"
-	out = []TranscodeOptions{TranscodeOptions{Oname: dir + "/encoded-audio.mp4", Profile: P144p30fps16x9}}
+	out = []TranscodeOptions{{Oname: dir + "/encoded-audio.mp4", Profile: P144p30fps16x9}}
 	res, err = Transcode3(in, out)
 	if err != nil {
 		t.Error(err)
@@ -948,31 +948,31 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	in := &TranscodeOptionsIn{Fname: "../transcoder/test.ts"}
-	out := []TranscodeOptions{TranscodeOptions{
+	out := []TranscodeOptions{{
 		Oname:        dir + "/videoonly.mp4",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		AudioEncoder: ComponentOptions{Name: "drop"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/audioonly.mp4",
 		VideoEncoder: ComponentOptions{Name: "drop"},
 		AudioEncoder: ComponentOptions{Name: "copy"},
-	}, TranscodeOptions{
+	}, {
 		// Avoids ADTS to ASC conversion
 		// which changes the bitstream
 		Oname:        dir + "/audioonly.ts",
 		VideoEncoder: ComponentOptions{Name: "drop"},
 		AudioEncoder: ComponentOptions{Name: "copy"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/audio.md5",
 		VideoEncoder: ComponentOptions{Name: "drop"},
 		AudioEncoder: ComponentOptions{Name: "copy"},
 		Muxer:        ComponentOptions{Name: "md5"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/video.md5",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		AudioEncoder: ComponentOptions{Name: "drop"},
 		Muxer:        ComponentOptions{Name: "md5"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/copy.mp4",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		AudioEncoder: ComponentOptions{Name: "copy"},
@@ -1021,11 +1021,11 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 
 	// Test specifying a copy or a drop for a stream that does not exist
 	in.Fname = dir + "/videoonly.mp4"
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/videoonly-copy.mp4",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		AudioEncoder: ComponentOptions{Name: "copy"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/videoonly-copy-2.mp4",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		AudioEncoder: ComponentOptions{Name: "drop"},
@@ -1037,7 +1037,7 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 
 	// Test mp4-to-mpegts; involves an implicit bitstream conversion to annex B
 	in.Fname = dir + "/videoonly.mp4"
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/videoonly-copy.ts",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 	}}
@@ -1047,7 +1047,7 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 	}
 	// sanity check the md5sum of the mp4-to-mpegts result
 	in.Fname = dir + "/videoonly-copy.ts"
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/videoonly-copy.md5",
 		VideoEncoder: ComponentOptions{Name: "copy"},
 		Muxer:        ComponentOptions{Name: "md5"},
@@ -1070,11 +1070,11 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 
 	// Encode one stream of a short sample while copying / dropping another
 	in.Fname = dir + "/test-short.ts"
-	out = []TranscodeOptions{TranscodeOptions{
+	out = []TranscodeOptions{{
 		Oname:        dir + "/encoded-video.mp4",
 		Profile:      P144p30fps16x9,
 		AudioEncoder: ComponentOptions{Name: "drop"},
-	}, TranscodeOptions{
+	}, {
 		Oname:        dir + "/encoded-audio.mp4",
 		VideoEncoder: ComponentOptions{Name: "drop"},
 	}}
@@ -1108,7 +1108,7 @@ func TestTranscoder_RepeatedTranscodes(t *testing.T) {
 
 	// Initial set up; convert 60fps input to 30fps (1 second's worth)
 	in := &TranscodeOptionsIn{Fname: dir + "/test-short.ts"}
-	out := []TranscodeOptions{TranscodeOptions{Oname: dir + "/0.ts", Profile: P144p30fps16x9}}
+	out := []TranscodeOptions{{Oname: dir + "/0.ts", Profile: P144p30fps16x9}}
 	res, err := Transcode3(in, out)
 	if err != nil || res.Decoded.Frames != 62 || res.Encoded[0].Frames != 31 {
 		t.Error("Unexpected preconditions ", err, res)
@@ -1131,7 +1131,7 @@ func TestTranscoder_RepeatedTranscodes(t *testing.T) {
 
 	// Do the same but with audio. This yields a 30fps file.
 	in = &TranscodeOptionsIn{Fname: dir + "/test-short-with-audio.ts"}
-	out = []TranscodeOptions{TranscodeOptions{Oname: dir + "/audio-0.ts", Profile: P144p30fps16x9}}
+	out = []TranscodeOptions{{Oname: dir + "/audio-0.ts", Profile: P144p30fps16x9}}
 	res, err = Transcode3(in, out)
 	if err != nil || res.Decoded.Frames != 60 || res.Encoded[0].Frames != 30 {
 		t.Error("Unexpected preconditions ", err, res)
@@ -1172,7 +1172,7 @@ func TestTranscoder_MismatchedEncodeDecode(t *testing.T) {
 	run(cmd)
 
 	in := &TranscodeOptionsIn{Fname: dir + "/test.ts"}
-	out := []TranscodeOptions{TranscodeOptions{Oname: dir + "/out.mp4", Profile: p144p60fps}}
+	out := []TranscodeOptions{{Oname: dir + "/out.mp4", Profile: p144p60fps}}
 	res, err := Transcode3(in, out)
 	if err != nil {
 		t.Error(err)
@@ -1219,8 +1219,8 @@ func TestTranscoder_MismatchedEncodeDecode(t *testing.T) {
 	// Sanity check we still get the same results with multiple outputs?
 	in.Fname = dir + "/test.ts"
 	out = []TranscodeOptions{
-		TranscodeOptions{Oname: dir + "/out2.ts", Profile: p144p60fps},
-		TranscodeOptions{Oname: dir + "/out2.mp4", Profile: p144p60fps},
+		{Oname: dir + "/out2.ts", Profile: p144p60fps},
+		{Oname: dir + "/out2.mp4", Profile: p144p60fps},
 	}
 	res, err = Transcode3(in, out)
 	if err != nil {
@@ -1323,7 +1323,7 @@ nb_read_frames=%d
 
 	// no audio + 60fps input
 	in := &TranscodeOptionsIn{Fname: dir + "/test-noaudio.ts"}
-	out := []TranscodeOptions{TranscodeOptions{
+	out := []TranscodeOptions{{
 		Oname:   dir + "/out-noaudio.ts",
 		Profile: P144p30fps16x9,
 	}}
@@ -1399,7 +1399,7 @@ func TestTranscoder_PassthroughFPS(t *testing.T) {
         ffprobe -v warning -select_streams v -show_frames test-short.ts | grep pkt_pts= > test-short.pts
     `
 	run(cmd)
-	out := []TranscodeOptions{TranscodeOptions{Profile: P144p30fps16x9}}
+	out := []TranscodeOptions{{Profile: P144p30fps16x9}}
 	out[0].Profile.Framerate = 0 // Passthrough!
 
 	// Check a somewhat normal passthru case

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -41,8 +41,6 @@ func TestSegmenter_DeleteSegments(t *testing.T) {
 
 	// sanity check that segmented outputs > playlist length
 	cmd := `
-		set -eux
-		cd "$0"
 		# default test.ts is a bit short so make it a bit longer
 		cp "$1/../transcoder/test.ts" test.ts
 		ffmpeg -loglevel warning -i "concat:test.ts|test.ts|test.ts" -c copy long.ts
@@ -60,8 +58,6 @@ func TestSegmenter_DeleteSegments(t *testing.T) {
 
 	// check that segments have been deleted by counting output ts files
 	cmd = `
-		set -eux
-		cd "$0"
 		[ $(ls out_*.ts | wc -l) -eq 6 ]
 	`
 	run(cmd)
@@ -76,9 +72,6 @@ func TestSegmenter_StreamOrdering(t *testing.T) {
 
 	// Craft an input that has a subtitle, audio and video stream, in that order
 	cmd := `
-	    set -eux
-	    cd "$0"
-
 		# generate subtitle file
 		cat <<- EOF > inp.srt
 			1
@@ -106,8 +99,6 @@ func TestSegmenter_StreamOrdering(t *testing.T) {
 
 	// check stream ordering in output file. Should be video, then audio
 	cmd = `
-		set -eux
-		cd $0
 		[ $(ffprobe -loglevel warning -i out_0.ts -show_streams | grep index | wc -l) -eq 2 ]
 		ffprobe -loglevel warning -i out_0.ts -show_streams -select_streams v | grep index=0
 		ffprobe -loglevel warning -i out_0.ts -show_streams -select_streams a | grep index=1
@@ -125,8 +116,6 @@ func TestSegmenter_DropLatePackets(t *testing.T) {
 
 	// Craft an input with an out-of-order timestamp
 	cmd := `
-		set -eux
-		cd "$0"
 		# borrow segmenter test file, rewrite a timestamp
 		cp "$1/../segmenter/test.flv" test.flv
 
@@ -150,9 +139,6 @@ func TestSegmenter_DropLatePackets(t *testing.T) {
 
 	// Now ensure things are as expected
 	cmd = `
-		set -eux
-		cd "$0"
-
 		# check monotonic timestamps (rescaled for the 90khz mpegts timebase)
 		ffprobe -loglevel quiet -show_packets -select_streams v out_0.ts | grep dts= | tail -3 | tr '\n' ',' | grep dts=1694970,dts=1698030,dts=1703970,
 
@@ -171,9 +157,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// Craft an input with an uneven res
 	cmd := `
-	    set -eux
-	    cd "$0"
-
 		# borrow the test.ts from the transcoder dir, output with 123x456 res
 		ffmpeg -loglevel warning -i "$1/../transcoder/test.ts" -c:a copy -c:v mpeg4 -s 123x456 test.mp4
 
@@ -201,8 +184,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// Check output resolutions
 	cmd = `
-		set -eux
-		cd "$0"
 		ffprobe -loglevel warning -show_streams -select_streams v out0test.mp4 | grep width=64
 		ffprobe -loglevel warning -show_streams -select_streams v out0test.mp4 | grep height=240
 		ffprobe -loglevel warning -show_streams -select_streams v out0test_larger.mp4 | grep width=64
@@ -212,8 +193,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// Transpose input and do the same checks as above.
 	cmd = `
-		set -eux
-		cd "$0"
 		ffmpeg -loglevel warning -i test.mp4 -c:a copy -c:v mpeg4 -vf transpose transposed.mp4
 
 		# sanity check resolutions
@@ -229,8 +208,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// Check output resolutions for transposed input
 	cmd = `
-		set -eux
-		cd "$0"
 		ffprobe -loglevel warning -show_streams -select_streams v out0transposed.mp4 | grep width=426
 		ffprobe -loglevel warning -show_streams -select_streams v out0transposed.mp4 | grep height=114
 	`
@@ -238,8 +215,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// check special case of square resolutions
 	cmd = `
-		set -eux
-		cd "$0"
 		ffmpeg -loglevel warning -i test.mp4 -c:a copy -c:v mpeg4 -s 123x123 square.mp4
 
 		# sanity check resolutions
@@ -255,9 +230,6 @@ func TestTranscoder_UnevenRes(t *testing.T) {
 
 	// Check output resolutions are still square
 	cmd = `
-		set -eux
-		cd "$0"
-		ls
 		ffprobe -loglevel warning -i out0square.mp4 -show_streams -select_streams v | grep width=426
 		ffprobe -loglevel warning -i out0square.mp4 -show_streams -select_streams v | grep height=426
 	`
@@ -273,9 +245,6 @@ func TestTranscoder_SampleRate(t *testing.T) {
 
 	// Craft an input with 48khz audio
 	cmd := `
-		set -eux
-		cd $0
-
 		# borrow the test.ts from the transcoder dir, output with 48khz audio
 		ffmpeg -loglevel warning -i "$1/../transcoder/test.ts" -c:v copy -af 'aformat=sample_fmts=fltp:channel_layouts=stereo:sample_rates=48000' -c:a aac -t 1.1 test.ts
 
@@ -310,8 +279,6 @@ func TestTranscoder_SampleRate(t *testing.T) {
 
 	// Ensure transcoded sample rate is 44k.1hz and check timestamps
 	cmd = `
-		set -eux
-		cd "$0"
 		ffprobe -loglevel warning -show_streams -select_streams a out0test.ts | grep sample_rate=44100
 
 		# Sample rate = 44.1khz, samples per frame = 1024
@@ -336,9 +303,6 @@ func TestTranscoder_Timestamp(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-		set -eux
-		cd $0
-
 		# prepare the input and sanity check 60fps
 		cp "$1/../transcoder/test.ts" inp.ts
 		ffprobe -loglevel warning -select_streams v -show_streams -count_frames inp.ts > inp.out
@@ -364,9 +328,6 @@ func TestTranscoder_Timestamp(t *testing.T) {
 	}
 
 	cmd = `
-		set -eux
-		cd $0
-
 		# hardcode some checks for now. TODO make relative to source.
 		ffprobe -loglevel warning -select_streams v -show_streams -count_frames out0test.ts > test.out
 		grep avg_frame_rate=30 test.out
@@ -446,8 +407,6 @@ func TestTranscoderStatistics_Decoded(t *testing.T) {
 	// Run them through the transcoder, and check the sum of pixels / frames match
 	// Ensures we can properly accommodate mid-stream resolution changes.
 	cmd := `
-        set -eux
-        cd "$0"
         cat out_0.ts out_1.ts out_2.ts out_3.ts > combined.ts
     `
 	run(cmd)
@@ -471,9 +430,6 @@ func TestTranscoder_Statistics_Encoded(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-        set -eux
-        cd $0
-
         # prepare 1-second input
         cp "$1/../transcoder/test.ts" inp.ts
         ffmpeg -loglevel warning -i inp.ts -c:a copy -c:v copy -t 1 test.ts
@@ -542,9 +498,6 @@ nb_read_frames=%d
 		f.Close()
 
 		cmd = fmt.Sprintf(`
-            set -eux
-            cd $0
-
             fname=out%d
 
             ffprobe -loglevel warning -hide_banner -count_frames -count_packets  -select_streams v -show_streams 2>&1 $fname.ts | grep '^width=\|^height=\|nb_read_frames=' > $fname.stats
@@ -565,9 +518,6 @@ func TestTranscoder_StatisticsAspectRatio(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-        set -eux
-        cd $0
-
         # prepare 1-second input
         cp "$1/../transcoder/test.ts" inp.ts
         ffmpeg -loglevel warning -i inp.ts -c:a copy -c:v copy -t 1 test.ts
@@ -593,9 +543,6 @@ func TestTranscoder_MuxerOpts(t *testing.T) {
 
 	// Prepare test environment : truncate input file
 	cmd := `
-        set -eux
-        cd $0
-
         cp "$1/../transcoder/test.ts" inp.ts
         ffmpeg -i inp.ts -c:a copy -c:v copy -t 1 inp-short.ts
     `
@@ -635,9 +582,6 @@ func TestTranscoder_MuxerOpts(t *testing.T) {
 	}
 
 	cmd = `
-        set -eux
-        cd $0
-
         # check formats and that options were used
         ffprobe -loglevel warning -show_format out-mkv.mp4 | grep format_name=matroska
         # ffprobe -loglevel warning -show_format out.mpd | grep format_name=dash # this fails so skip for now
@@ -659,9 +603,6 @@ func TestTranscoder_EncoderOpts(t *testing.T) {
 
 	// Prepare test environment : truncate input file
 	cmd := `
-        set -eux
-        cd $0
-
         # truncate input
         ffmpeg -i "$1/../transcoder/test.ts" -c:a copy -c:v copy -t 1 test.ts
 
@@ -691,9 +632,6 @@ func TestTranscoder_EncoderOpts(t *testing.T) {
 	}
 
 	cmd = `
-        set -eux
-        cd $0
-
         # Check codecs are what we expect them to be
         ffprobe -show_streams -select_streams v out.nut | grep codec_name=snow
         ffprobe -show_streams -select_streams a out.nut | grep codec_name=vorbis
@@ -712,8 +650,6 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 
 	// Set up inputs, truncate test file
 	cmd := `
-        set -eux
-        cd "$0"
         cp "$1"/../transcoder/test.ts .
         ffmpeg -i test.ts -c:a copy -c:v copy -t 1 test-short.ts
 
@@ -748,9 +684,6 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 	}
 
 	cmd = `
-        set -eux
-        cd "$0"
-
         # extract video track only, compare md5sums
         ffmpeg -i test-short.ts -an -c:v copy -f md5 test-video.md5
         ffmpeg -i videocopy.ts -an -c:v copy -f md5 videocopy.md5
@@ -765,9 +698,6 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 
 	// Test stream copy when no stream exists in file
 	cmd = `
-        set -eux
-        cd "$0"
-
         ffmpeg -i test-short.ts -an -c:v copy videoonly.ts
         ffmpeg -i test-short.ts -vn -c:a copy audioonly.ts
 
@@ -859,8 +789,6 @@ func TestTranscoder_Drop(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-        set -eux
-        cd "$0"
         cp "$1"/../transcoder/test.ts .
         ffmpeg -i test.ts -c:a copy -c:v copy -t 1 test-short.ts
 
@@ -985,9 +913,6 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 		t.Error("Unexpected count for decoded frames ", res.Decoded.Frames)
 	}
 	cmd := `
-        set -eux
-        cd $0
-
         cp "$1"/../transcoder/test.ts .
 
         # truncate input for later use
@@ -1057,9 +982,6 @@ func TestTranscoder_StreamCopyAndDrop(t *testing.T) {
 		t.Error(err)
 	}
 	cmd = `
-        set -eux
-        cd "$0"
-
         # use ffmpeg to convert the existing mp4 to ts and check match
         # for some reason this does NOT match the original mpegts
         ffmpeg -i videoonly.mp4 -c:v copy -f mpegts ffmpeg-mp4to.ts
@@ -1162,9 +1084,6 @@ func TestTranscoder_MismatchedEncodeDecode(t *testing.T) {
 	p144p60fps.Framerate = 60
 
 	cmd := `
-        set -eux
-        cd $0
-
         # prepare 1-second input
         cp "$1/../transcoder/test.ts" inp.ts
         ffmpeg -loglevel warning -i inp.ts -c:a copy -c:v copy -t 1 test.ts

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1160,7 +1160,7 @@ func TestTranscoder_MismatchedEncodeDecode(t *testing.T) {
 		t.Error("Sanity check of mpegts failed ", res2.Decoded.Frames, res.Encoded[0].Frames)
 	}
 	if res3.Decoded.Frames != 60 || res.Encoded[1].Frames != 61 {
-		t.Error("Sanity check of mp4 failed ", res2.Decoded.Frames, res.Encoded[1].Frames)
+		t.Error("Sanity check of mp4 failed ", res3.Decoded.Frames, res.Encoded[1].Frames)
 	}
 }
 

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -16,9 +16,6 @@ func TestNvidia_Transcoding(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-    set -eux
-    cd "$0"
-
     # set up initial input; truncate test.ts file
     ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
   `
@@ -90,8 +87,6 @@ func TestNvidia_Transcoding(t *testing.T) {
 	}
 
 	cmd = `
-    set -eux
-    cd "$0"
     # compare using ssim and generate stats file
     ffmpeg -loglevel warning -i out.ts -i sw.ts -lavfi '[0:v][1:v]ssim=stats.log' -f null -
     # check image quality; ensure that no more than 5 frames have ssim < 0.95
@@ -228,9 +223,6 @@ func TestNvidia_Transcoding_Multiple(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-    set -eux
-    cd "$0"
-
     # set up initial input; truncate test.ts file
     ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
 
@@ -420,9 +412,6 @@ func TestNvidia_DrainFilters(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-    set -eux
-    cd "$0"
-
     # set up initial input; truncate test.ts file
     ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -t 1 test.ts
   `
@@ -450,9 +439,6 @@ func TestNvidia_DrainFilters(t *testing.T) {
 	}
 
 	cmd = `
-    set -eux
-    cd "$0"
-
     # sanity check with ffmpeg itself
     ffmpeg -loglevel warning -i test.ts -c:a copy -c:v libx264 -vf fps=100 -vsync 0 ffmpeg-out.ts
     ffprobe -loglevel warning -show_streams -select_streams v -count_frames ffmpeg-out.ts > ffmpeg,out
@@ -480,9 +466,6 @@ func TestNvidia_CountFrames(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cmd := `
-    set -eux
-    cd "$0"
-
     # run segmenter and sanity check frame counts . Hardcode for now.
     ffmpeg -loglevel warning -i "$1"/../transcoder/test.ts -c:a copy -c:v copy -f hls test.m3u8
     ffprobe -loglevel warning -select_streams v -count_frames -show_streams test0.ts | grep nb_read_frames=120

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -34,7 +34,7 @@ func TestNvidia_Transcoding(t *testing.T) {
 		Fname: fname,
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Software,
@@ -49,7 +49,7 @@ func TestNvidia_Transcoding(t *testing.T) {
 		Fname: fname,
 		Accel: Software,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -64,7 +64,7 @@ func TestNvidia_Transcoding(t *testing.T) {
 		Fname: fname,
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -79,7 +79,7 @@ func TestNvidia_Transcoding(t *testing.T) {
 		Fname: fname,
 		Accel: Software,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   dir + "/sw.ts",
 			Profile: prof,
 			Accel:   Software,
@@ -127,7 +127,7 @@ func TestNvidia_Pixfmts(t *testing.T) {
 		Fname: dir + "/in420p.mp4",
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   dir + "/out420p.mp4",
 			Profile: prof,
 			Accel:   Nvidia,
@@ -142,7 +142,7 @@ func TestNvidia_Pixfmts(t *testing.T) {
 		Fname: dir + "/in422p.mp4",
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   dir + "/out422p.mp4",
 			Profile: prof,
 			Accel:   Software,
@@ -162,7 +162,6 @@ func TestNvidia_Pixfmts(t *testing.T) {
 	// Following test vaidates YUV 4:4:4 pixel format encoding which is only supported on limited set of devices for e.g. P100
 	// https://developer.nvidia.com/video-encode-decode-gpu-support-matrix
 
-
 	// check valid and invalid pixel formats
 	cmd = `
     # generate semi-supported 444p type (encoding only)
@@ -171,14 +170,13 @@ func TestNvidia_Pixfmts(t *testing.T) {
   `
 	run(cmd)
 
-
 	// 444p is encodeable but not decodeable; produces a different error
 	// that is only caught at decode time. Attempt to detect decode bailout.
 	err = Transcode2(&TranscodeOptionsIn{
 		Fname: dir + "/in444p.mp4",
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   dir + "/out444p.mp4",
 			Profile: prof,
 			Accel:   Nvidia,
@@ -195,7 +193,7 @@ func TestNvidia_Pixfmts(t *testing.T) {
 		Fname: dir + "/in422p.mp4",
 		Accel: Software,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   dir + "/out422_to_default.mp4",
 			Profile: prof,
 			Accel:   Nvidia,
@@ -248,30 +246,30 @@ func TestNvidia_Transcoding_Multiple(t *testing.T) {
 
 	mkoname := func(i int) string { return fmt.Sprintf("%s/%d.ts", dir, i) }
 	out := []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname: mkoname(0),
 			// pass through resolution has different behavior;
 			// basically bypasses the scale filter
 			Profile: orig,
 			Accel:   Nvidia,
 		},
-		TranscodeOptions{
+		{
 			Oname:   mkoname(1),
 			Profile: prof,
 			Accel:   Nvidia,
 		},
-		TranscodeOptions{
+		{
 			Oname:   mkoname(2),
 			Profile: orig,
 			Accel:   Software,
 		},
-		TranscodeOptions{
+		{
 			Oname:   mkoname(3),
 			Profile: prof,
 			Accel:   Software,
 		},
 		// another gpu rendition for good measure?
-		TranscodeOptions{
+		{
 			Oname:   mkoname(4),
 			Profile: prof,
 			Accel:   Nvidia,
@@ -317,7 +315,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Accel:  Nvidia,
 		Device: device,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Software,
@@ -332,7 +330,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Fname: fname,
 		Accel: Software,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -349,7 +347,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Accel:  Nvidia,
 		Device: device,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -365,7 +363,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Accel:  Nvidia,
 		Device: "0",
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -382,7 +380,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Accel:  Nvidia,
 		Device: "9999",
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Software,
@@ -397,7 +395,7 @@ func TestNvidia_Devices(t *testing.T) {
 		Fname: fname,
 		Accel: Software,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -441,7 +439,7 @@ func TestNvidia_DrainFilters(t *testing.T) {
 		Fname: fname,
 		Accel: Nvidia,
 	}, []TranscodeOptions{
-		TranscodeOptions{
+		{
 			Oname:   oname,
 			Profile: prof,
 			Accel:   Nvidia,
@@ -541,15 +539,15 @@ func TestNvidia_CountEncodedFrames(t *testing.T) {
 		p60fps.Framerate = 60
 		p120fps := P144p30fps16x9
 		p120fps.Framerate = 120
-		out := []TranscodeOptions{TranscodeOptions{
+		out := []TranscodeOptions{{
 			Oname:   fmt.Sprintf("%s/out_30fps_%d.ts", dir, i),
 			Profile: P144p30fps16x9,
 			Accel:   Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/out_60fps_%d.ts", dir, i),
 			Profile: p60fps,
 			Accel:   Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/out_120fps_%d.ts", dir, i),
 			Profile: p120fps,
 			Accel:   Nvidia,
@@ -584,7 +582,7 @@ func TestNvidia_RepeatedSpecialOpts(t *testing.T) {
 	// At some point we forgot to set the muxer type in reopened outputs
 	// This used to cause an error, so just check that it's resolved
 	in := &TranscodeOptionsIn{Accel: Nvidia}
-	out := []TranscodeOptions{TranscodeOptions{
+	out := []TranscodeOptions{{
 		Oname:        "-",
 		Profile:      P144p30fps16x9,
 		VideoEncoder: ComponentOptions{Opts: map[string]string{"zerolatency": "1"}},
@@ -615,21 +613,21 @@ func TestNvidia_API_MixedOutput(t *testing.T) {
 	tc := NewTranscoder()
 	for i := 0; i < 4; i++ {
 		in := &TranscodeOptionsIn{Fname: fmt.Sprintf("%s/out_%d.ts", dir, i)}
-		out := []TranscodeOptions{TranscodeOptions{
+		out := []TranscodeOptions{{
 			Oname:        fmt.Sprintf("%s/%d.md5", dir, i),
 			AudioEncoder: ComponentOptions{Name: "drop"},
 			VideoEncoder: ComponentOptions{Name: "copy"},
 			Muxer:        ComponentOptions{Name: "md5"},
-		}, TranscodeOptions{
+		}, {
 			Oname:        fmt.Sprintf("%s/nv_%d.ts", dir, i),
 			Profile:      profile,
 			AudioEncoder: ComponentOptions{Name: "copy"},
 			Accel:        Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/nv_audio_encode_%d.ts", dir, i),
 			Profile: profile,
 			Accel:   Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/sw_%d.ts", dir, i),
 			Profile: profile,
 		}}
@@ -702,21 +700,21 @@ func TestNvidia_API_AlternatingTimestamps(t *testing.T) {
 	idx := []int{1, 0, 3, 2}
 	for _, i := range idx {
 		in := &TranscodeOptionsIn{Fname: fmt.Sprintf("%s/out_%d.ts", dir, i)}
-		out := []TranscodeOptions{TranscodeOptions{
+		out := []TranscodeOptions{{
 			Oname:        fmt.Sprintf("%s/%d.md5", dir, i),
 			AudioEncoder: ComponentOptions{Name: "drop"},
 			VideoEncoder: ComponentOptions{Name: "copy"},
 			Muxer:        ComponentOptions{Name: "md5"},
-		}, TranscodeOptions{
+		}, {
 			Oname:        fmt.Sprintf("%s/nv_%d.ts", dir, i),
 			Profile:      profile,
 			AudioEncoder: ComponentOptions{Name: "copy"},
 			Accel:        Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/nv_audio_encode_%d.ts", dir, i),
 			Profile: profile,
 			Accel:   Nvidia,
-		}, TranscodeOptions{
+		}, {
 			Oname:   fmt.Sprintf("%s/sw_%d.ts", dir, i),
 			Profile: profile,
 		}}


### PR DESCRIPTION
https://github.com/livepeer/lpms/commit/248f7f490b112d302afa677a244f16b0f8b39c2a ffmpeg: Refactor a bit of output cleanup. …
Hopefully the intent of the renamed functions are clearer.

https://github.com/livepeer/lpms/commit/ad4848e2755d2e9623209f59c92b8b95ac518164 ffmpeg: Apply latest gofmt to tests.

55f2672 ffmpeg: Remove unneeded function preamble. …
The preamble is applied automatically now.

1532688 ffmpeg: Fix typo in test logging.

https://github.com/livepeer/lpms/commit/3f516780740f977b5ef7665dd0fa273f363ad80c README: Add audio to example command line. (supersedes https://github.com/livepeer/lpms/pull/175 )