### PR TITLE
vidplayer: Allow any file extension through.

### DIFF
--- a/vidplayer/player_test.go
+++ b/vidplayer/player_test.go
@@ -78,14 +78,6 @@ func stubGetSegNotFound(url *url.URL) ([]byte, error) {
 
 func TestHLS(t *testing.T) {
 	rec := httptest.NewRecorder()
-	handleLive(rec, httptest.NewRequest("GET", "/badpath", strings.NewReader("")), stubGetMasterPL, stubGetMediaPL, stubGetSeg)
-	if rec.Result().StatusCode != 400 {
-		t.Errorf("Expecting 400 because of bad path, but got: %v", rec.Result().StatusCode)
-	}
-	handleLive(rec, httptest.NewRequest("GET", "/seg.webm", strings.NewReader("")), stubGetMasterPL, stubGetMediaPL, stubGetSeg)
-	if rec.Result().StatusCode != 400 {
-		t.Errorf("Expecting 400 because of bad path, but got: %v", rec.Result().StatusCode)
-	}
 
 	//Test getting master playlist
 	rec = httptest.NewRecorder()


### PR DESCRIPTION
Whenever I get the sense that something smells wrong, it usually ends up being correct.

The old behavior ended up being unnecessarily restrictive.
In particular, go-livepeer now stores `.tempfile` extensions
for local temporary storage, and that hits this code path. No reason
why it shouldn't work.

https://github.com/livepeer/go-livepeer/blob/4ba2a732a31b673254008faeb903e28bf7039a74/core/orchestrator.go#L499-L506