### PR TITLE
ffmpeg: Exit early for non-H264 input w/ NVDEC

### DIFF
--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -37,6 +37,7 @@ func error_map() map[int]error {
 		{code: C.lpms_ERR_FILTERS, desc: "Error initializing filtergraph"},
 		{code: C.lpms_ERR_OUTPUTS, desc: "Too many outputs"},
 		{code: C.lpms_ERR_DTS, desc: "Segment out of order"},
+		{code: C.lpms_ERR_INPUT_CODEC, desc: "Unsupported input codec"},
 	}
 	for _, v := range lpmsErrors {
 		m[int(v.code)] = errors.New(v.desc)

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -11,6 +11,7 @@
 
 // Not great to appropriate internal API like this...
 const int lpms_ERR_INPUT_PIXFMT = FFERRTAG('I','N','P','X');
+const int lpms_ERR_INPUT_CODEC = FFERRTAG('I','N','P','C');
 const int lpms_ERR_FILTERS = FFERRTAG('F','L','T','R');
 const int lpms_ERR_PACKET_ONLY = FFERRTAG('P','K','O','N');
 const int lpms_ERR_OUTPUTS = FFERRTAG('O','U','T','P');
@@ -833,8 +834,11 @@ static int open_video_decoder(input_params *params, struct input_ctx *ctx)
   else if (ctx->vi < 0) {
     fprintf(stderr, "No video stream found in input\n");
   } else {
-    if (AV_CODEC_ID_H264 == codec->id &&
-        AV_HWDEVICE_TYPE_CUDA == params->hw_type) {
+    if (AV_HWDEVICE_TYPE_CUDA == params->hw_type) {
+      if (AV_CODEC_ID_H264 != codec->id) {
+        ret = lpms_ERR_INPUT_CODEC;
+        dd_err("Non H264 codec detected in input\n");
+      }
       AVCodec *c = avcodec_find_decoder_by_name("h264_cuvid");
       if (c) codec = c;
       else fprintf(stderr, "Cuvid decoder not found; defaulting to software\n");

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -6,6 +6,7 @@
 
 // LPMS specific errors
 extern const int lpms_ERR_INPUT_PIXFMT;
+extern const int lpms_ERR_INPUT_CODEC;
 extern const int lpms_ERR_FILTERS;
 extern const int lpms_ERR_OUTPUTS;
 extern const int lpms_ERR_DTS;


### PR DESCRIPTION
Resolves #185

Tested manually with the mpegts file in #185 - it now throws the correct error. (Still segfaults later though):
```$ ./transcoding segment.ts P240p25fps16x9 nv 0
Setting fname segment.ts encoding 1 renditions with nv
[mpegvideo @ 0x42b5480] Format mpegvideo detected only with low score of 12, misdetection possible!
Non H264 codec detected in input
Unable to open video decoder
Freeing input based on OPEN INPUT error
ERROR: logging before flag.Parse: E0414 18:54:09.197087  119394 ffmpeg.go:318] Transcoder Return : <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5cdcae]

goroutine 1 [running]:
main.main()
            /home/darkapex/go/src/github.com/livepeer/lpms/cmd/transcoding/transcoding.go:78 +0x37e
```