### PR TITLE
ffmpeg: use NULL flushing for decoder

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -973,6 +973,7 @@ int process_in(struct input_ctx *ictx, int framecount, AVFrame *frame, AVPacket 
 }
   int ret = 0;
 
+  //printf("TRACE: %s --- read frame count %d\n",__func__, framecount);
   // Read a packet and attempt to decode it.
   // If decoding was not possible, return the packet anyway for streamcopy
   av_init_packet(pkt);
@@ -1007,9 +1008,11 @@ int process_in(struct input_ctx *ictx, int framecount, AVFrame *frame, AVPacket 
       }
     }
 
+    //printf("\tvid: %d, Sent packet pts %ld, ret %d\n", ist->index == ictx->vi, pkt->pts, ret);
     ret = avcodec_send_packet(decoder, pkt);
     if (ret < 0) dec_err("Error sending packet to decoder\n");
     ret = avcodec_receive_frame(decoder, frame);
+    //printf("\tRecv frame pts %ld, ret %d\n", frame->pts, ret);
     if (ret == AVERROR(EAGAIN)) {
       // Distinguish from EAGAIN that may occur with
       // av_read_frame or avcodec_send_packet
@@ -1046,7 +1049,9 @@ dec_flush:
       // Classic flushing by sending NULL packets to decoder
       ictx->flushing = 1;
       ret = avcodec_send_packet(ictx->vc, NULL);
+      //printf("\tvid: 1, Sent flush packet ret %d\n", ret);
       ret = avcodec_receive_frame(ictx->vc, frame);
+      //printf("\tRecv frame pts %ld, ret %d\n", frame->pts, ret);
       if (ret == AVERROR_EOF) {
         avcodec_flush_buffers(ictx->vc);
         ictx->flushed = 1;
@@ -1098,6 +1103,7 @@ int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* octx, AVS
   int ret = 0;
   AVPacket pkt = {0};
 
+  //printf("TRACE: %s --- frame: %d, pts : %d\n",__func__, frame, (frame)?frame->pts:-1);
   if (AVMEDIA_TYPE_VIDEO == ost->codecpar->codec_type && frame) {
     if (!octx->res->frames) {
       frame->pict_type = AV_PICTURE_TYPE_I;
@@ -1150,6 +1156,7 @@ int process_out(struct input_ctx *ictx, struct output_ctx *octx, AVCodecContext 
   int ret = 0;
   int is_flushing = 0;
 
+  //printf("TRACE: %s --- infpts: %d\n",__func__, (inf) ? inf->pts: -1);
   if (!encoder) proc_err("Trying to transmux; not supported")
 
   if (!filter || !filter->active) {
@@ -1170,11 +1177,17 @@ int process_out(struct input_ctx *ictx, struct output_ctx *octx, AVCodecContext 
   // Start filter flushing process if necessary
   if (!inf && !filter->flushed) {
     // Set input frame to the last frame
-    // And increment pts offset by pkt_duration
-    // TODO It may make sense to use the expected output packet duration instead
+    // And increment pts offset by expected output packet duration
+    // expected output pts = (input_pts / pkt_duration) * (output_fps / input_fps)
     int is_video = AVMEDIA_TYPE_VIDEO == ost->codecpar->codec_type;
     AVFrame *frame = is_video ? ictx->last_frame_v : ictx->last_frame_a;
-    filter->flush_offset += frame->pkt_duration;
+    int64_t dur = frame->pkt_duration;
+    if (is_video && octx->fps.den && !octx->res->frames) {
+      // adjust if: is video, using fps filter, and haven't encoded anything yet
+      AVStream *ist = ictx->ic->streams[ictx->vi];
+      dur = av_rescale_q(frame->pkt_duration, ist->r_frame_rate, octx->fps);
+    }
+    filter->flush_offset += dur;
     inf = frame;
     inf->opaque = (void*)inf->pts; // value doesn't matter; just needs to be set
     is_flushing = 1;

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -764,4 +764,55 @@ func TestNvidia_API_AlternatingTimestamps(t *testing.T) {
 	tc.StopTranscoder()
 }
 
+func TestNvidia_ShortSegments(t *testing.T) {
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+    # generate 1-frame segments
+    cp "$1/../transcoder/test.ts" .
+
+    ffmpeg -loglevel warning -ss 0 -i test.ts -c copy -frames:v 1 -copyts short0.ts
+    ffmpeg -loglevel warning -ss 2 -i test.ts -c copy -frames:v 1 -copyts short1.ts
+    ffmpeg -loglevel warning -ss 4 -i test.ts -c copy -frames:v 1 -copyts short2.ts
+    ffmpeg -loglevel warning -ss 6 -i test.ts -c copy -frames:v 1 -copyts short3.ts
+
+    ffprobe -loglevel warning -count_frames -show_streams -select_streams v short0.ts | grep nb_read_frames=1
+    ffprobe -loglevel warning -count_frames -show_streams -select_streams v short1.ts | grep nb_read_frames=1
+    ffprobe -loglevel warning -count_frames -show_streams -select_streams v short2.ts | grep nb_read_frames=1
+    ffprobe -loglevel warning -count_frames -show_streams -select_streams v short3.ts | grep nb_read_frames=1
+  `
+	run(cmd)
+
+	tc := NewTranscoder()
+	defer tc.StopTranscoder()
+	for i := 0; i < 4; i++ {
+		fname := fmt.Sprintf("%s/short%d.ts", dir, i)
+		t.Log("fname ", fname)
+		in := &TranscodeOptionsIn{Fname: fname, Accel: Nvidia}
+		out := []TranscodeOptions{{Oname: dir + "/out.ts", Profile: P144p30fps16x9, Accel: Nvidia}}
+		res, err := tc.Transcode(in, out)
+		if err != nil {
+			t.Error(err)
+		}
+		if 1 != res.Decoded.Frames {
+			t.Error("Did not decode expected number of frames: ", res.Decoded.Frames)
+		}
+		if 0 == res.Encoded[0].Frames {
+			// not sure what should be a reasonable number here
+			t.Error("Did not encode any frames: ", res.Encoded[0].Frames)
+		}
+	}
+
+	// Also test:
+	//  stream copy (both in conjunction with transcoding and standalone)
+	//  stream dropping (both in conjunction with transcoding and standalone)
+	//  framerate pass through
+	//  transcode low frame rate to low frame rate
+	//  other sanity checks for slightly higher frame numbers -
+	//   try 2, 3, 5 frames in addition to the 1 frame test case above.
+	// also test non-cuda, eg via api_test.go
+	// parameterize test sequence for all the above?
+}
+
 // XXX test bframes or delayed frames


### PR DESCRIPTION
**WIP**

Passing the framecount to `process_in` feels unclean.

Should we instead keep a flag called `needs_null_flushing` within input_ctx, and let process_in set it to false once it sees that CUDA has started returning frames?

This can also replace the new enum I think.