### PR TITLE
ffmpeg: Fix short segments flushing without using NULL packets

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -764,4 +764,13 @@ func TestNvidia_API_AlternatingTimestamps(t *testing.T) {
 	tc.StopTranscoder()
 }
 
+func TestNvidia_ShortSegments(t *testing.T) {
+	shortSegments(t, Nvidia, 1)
+	shortSegments(t, Nvidia, 2)
+	shortSegments(t, Nvidia, 3)
+	shortSegments(t, Nvidia, 5)
+	shortSegments(t, Nvidia, 6)
+	shortSegments(t, Nvidia, 10)
+}
+
 // XXX test bframes or delayed frames


### PR DESCRIPTION
* Maintain diff of sent packets/recv frames to know when decoder is done flushing.
* Stop sending sentinel packets after n=5 attempts of not getting any valid frame back.
* Fix fps filter dropping 1-frame segments by sending a flush frame with a longer pts.
* Add parameterized unit tests to reproduce #168 

In #187 I tried to fix the short segment flushing using NULL packets, but it had heavy performance impact. So I've created this fresh PR because that got very messy.

I tried my best to benchmark this against master and it seems to perform equally well. I noob though, pls verify :)