### PR TITLE
Support non-integer framerates

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -773,4 +773,8 @@ func TestNvidia_ShortSegments(t *testing.T) {
 	shortSegments(t, Nvidia, 10)
 }
 
+func TestNvidia_FractionalFPS(t *testing.T) {
+	fractionalFPS(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -26,12 +26,13 @@ const (
 //240p30fps: 700kbps
 //144p30fps: 400kbps
 type VideoProfile struct {
-	Name        string
-	Bitrate     string
-	Framerate   uint
-	Resolution  string
-	AspectRatio string
-	Format      Format
+	Name         string
+	Bitrate      string
+	Framerate    uint
+	FramerateDen uint
+	Resolution   string
+	AspectRatio  string
+	Format       Format
 }
 
 //Some sample video profiles


### PR DESCRIPTION
**Why?**
These changes are for supporting non-integer FPS output in LPMS. See [go-livepeer#1474](https://github.com/livepeer/go-livepeer/issues/1474) for details.

**What?**
* Add a `FramerateDen` field in VideoProfile
* Set the rational FPS in the FFmpeg filtergraph string & Cgo transcoder params
* Add unit tests to verify that common fractional FPS cases work as expected