### PR TITLE
Fix processing of consecutive MP4 segments

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -930,17 +930,11 @@ static int open_input(input_params *params, struct input_ctx *ctx)
   goto open_input_err; \
 }
   AVFormatContext *ic   = NULL;
-  AVIOContext *pb       = NULL;
   char *inp = params->fname;
   int ret = 0;
 
   // open demuxer
-  ic = avformat_alloc_context();
-  if (!ic) dd_err("demuxer: Unable to alloc context\n");
-  ret = avio_open(&pb, inp, AVIO_FLAG_READ);
-  if (ret < 0) dd_err("demuxer: Unable to open file\n");
-  ic->pb = pb;
-  ret = avformat_open_input(&ic, NULL, NULL, NULL);
+  ret = avformat_open_input(&ic, inp, NULL, NULL);
   if (ret < 0) dd_err("demuxer: Unable to open input\n");
   ctx->ic = ic;
   ret = avformat_find_stream_info(ic, NULL);
@@ -958,8 +952,6 @@ static int open_input(input_params *params, struct input_ctx *ctx)
 
 open_input_err:
   fprintf(stderr, "Freeing input based on OPEN INPUT error\n");
-  avio_close(pb); // need to close manually, avformat_open_input
-                  // not closes it in case of error
   free_input(ctx);
   return ret;
 #undef dd_err

--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -1350,7 +1350,7 @@ int transcode(struct transcode_thread *h,
         ret = avio_open(&octx->oc->pb, octx->fname, AVIO_FLAG_WRITE);
         if (ret < 0) main_err("Error re-opening output file\n");
       }
-      ret = avformat_write_header(octx->oc, NULL);
+      ret = avformat_write_header(octx->oc, &octx->muxer->opts);
       if (ret < 0) main_err("Error re-writing header\n");
   }
 

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -777,4 +777,8 @@ func TestNvidia_FractionalFPS(t *testing.T) {
 	fractionalFPS(t, Nvidia)
 }
 
+func TestNvidia_ConsecutiveMP4s(t *testing.T) {
+	consecutiveMP4s(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -781,4 +781,8 @@ func TestNvidia_ConsecutiveMP4s(t *testing.T) {
 	consecutiveMP4s(t, Nvidia)
 }
 
+func TestNvidia_ConsecutiveMuxerOpts(t *testing.T) {
+	consecutiveMuxerOpts(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames


### PR DESCRIPTION
Fixes a number of issues around handling consecutive MP4 segments.

Closes https://github.com/livepeer/go-livepeer/issues/1514

ffmpeg: Fix decoding consecutive MP4s. … 9e0d589
A new demuxer has to be initialized for each non-mpegts input.
Preserving the old behavior saves 1% of performance.

ffmpeg: Short-circuit flushing + demuxer reset. … 8746b09
No longer have to force a read until EOF if exiting early.
Does not change anything, but it's a better way of doing things.

ffmpeg: Apply muxer options to consecutive segments with GPU transcoding … 16f55a1
For VideoProfile-directed mp4 outputs, this resulted in trailing moov.