### PR TITLE
ffmpeg: Add support for H264 profiles

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -785,4 +785,8 @@ func TestNvidia_ConsecutiveMuxerOpts(t *testing.T) {
 	consecutiveMuxerOpts(t, Nvidia)
 }
 
+func TestNvidia_EncoderProfiles(t *testing.T) {
+	encodingProfiles(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -16,6 +16,16 @@ const (
 	FormatMP4
 )
 
+type Profile int
+
+const (
+	ProfileNone Profile = iota
+	ProfileH264Baseline
+	ProfileH264Main
+	ProfileH264High
+	ProfileH264ConstrainedHigh
+)
+
 //Standard Profiles:
 //1080p60fps: 9000kbps
 //1080p30fps: 6000kbps
@@ -33,6 +43,7 @@ type VideoProfile struct {
 	Resolution   string
 	AspectRatio  string
 	Format       Format
+	Profile      Profile
 }
 
 //Some sample video profiles
@@ -77,6 +88,14 @@ var FormatExtensions = map[Format]string{
 var ExtensionFormats = map[string]Format{
 	".ts":  FormatMPEGTS,
 	".mp4": FormatMP4,
+}
+
+var ProfileParameters = map[Profile]string{
+	ProfileNone:                "",
+	ProfileH264Baseline:        "baseline",
+	ProfileH264Main:            "main",
+	ProfileH264High:            "high",
+	ProfileH264ConstrainedHigh: "high",
 }
 
 func VideoProfileResolution(p VideoProfile) (int, int, error) {


### PR DESCRIPTION
### Why?
Refer to the parent issue in go-livepeer: https://github.com/livepeer/go-livepeer/issues/1531

### What?
* Add a new enum for Encoder profiles
* Add a field in VideoProfile struct to hold the encoder (h264) profile
* Pass the relevant AVOptions to FFmpeg to enable the profile
  * Support *Constrained High* by disabling B-frames using `-bf 0`

### Testing?
* Manually tested all profiles work as expected
* Manually tested by default no extra AVOption is passed so that encoder uses default profile (nvidia default is `main`, x264 default is `high`)
* Added unit tests for all the profiles, including B-frames verification for Baseline & Constrained High