### PR TITLE
ffmpeg: Knob to tune output GOP intervals.

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -23,6 +23,7 @@ var ErrTranscoderInp = errors.New("TranscoderInvalidInput")
 var ErrTranscoderStp = errors.New("TranscoderStopped")
 var ErrTranscoderFmt = errors.New("TranscoderUnrecognizedFormat")
 var ErrTranscoderPrf = errors.New("TranscoderUnrecognizedProfile")
+var ErrTranscoderGOP = errors.New("TranscoderInvalidGOP")
 
 type Acceleration int
 
@@ -274,6 +275,17 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 				// Do nothing, the encoder will use default profile
 			default:
 				return nil, ErrTranscoderPrf
+			}
+		}
+		if param.GOP != 0 {
+			if param.GOP <= GOPInvalid {
+				return nil, ErrTranscoderGOP
+			} else {
+				if param.Framerate > 0 {
+					gop := param.GOP.Seconds()
+					interval := strconv.Itoa(int(gop * float64(param.Framerate)))
+					p.VideoEncoder.Opts["g"] = interval
+				}
 			}
 		}
 		vidOpts := C.component_opts{

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -281,6 +281,10 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		if param.GOP != 0 {
 			if param.GOP <= GOPInvalid {
 				return nil, ErrTranscoderGOP
+			}
+			// Check for intra-only
+			if param.GOP == GOPIntraOnly {
+				p.VideoEncoder.Opts["g"] = "0"
 			} else {
 				if param.Framerate > 0 {
 					gop := param.GOP.Seconds()

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -277,6 +277,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 				return nil, ErrTranscoderPrf
 			}
 		}
+		gopMs := 0
 		if param.GOP != 0 {
 			if param.GOP <= GOPInvalid {
 				return nil, ErrTranscoderGOP
@@ -285,6 +286,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 					gop := param.GOP.Seconds()
 					interval := strconv.Itoa(int(gop * float64(param.Framerate)))
 					p.VideoEncoder.Opts["g"] = interval
+				} else {
+					gopMs = int(param.GOP.Milliseconds())
 				}
 			}
 		}
@@ -306,7 +309,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		defer C.free(unsafe.Pointer(vfilt))
 		params[i] = C.output_params{fname: oname, fps: fps,
 			w: C.int(w), h: C.int(h), bitrate: C.int(bitrate),
-			muxer: muxOpts, audio: audioOpts, video: vidOpts, vfilters: vfilt}
+			gop_time: C.int(gopMs),
+			muxer:    muxOpts, audio: audioOpts, video: vidOpts, vfilters: vfilt}
 		defer func(param *C.output_params) {
 			// Work around the ownership rules:
 			// ffmpeg normally takes ownership of the following AVDictionary options

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -21,7 +21,7 @@ typedef struct {
 typedef struct {
   char *fname;
   char *vfilters;
-  int w, h, bitrate;
+  int w, h, bitrate, gop_time;
   AVRational fps;
 
   component_opts muxer;

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -789,4 +789,8 @@ func TestNvidia_EncoderProfiles(t *testing.T) {
 	encodingProfiles(t, Nvidia)
 }
 
+func TestNvidia_SetGOPs(t *testing.T) {
+	setGops(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -30,8 +30,10 @@ const (
 // For additional "special" GOP values
 // enumerate backwards from here
 const (
+	GOPIntraOnly time.Duration = -1
+
 	// Must always be last. Renumber as needed.
-	GOPInvalid = -1
+	GOPInvalid = -2
 )
 
 //Standard Profiles:

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -3,6 +3,7 @@ package ffmpeg
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/m3u8"
@@ -26,6 +27,13 @@ const (
 	ProfileH264ConstrainedHigh
 )
 
+// For additional "special" GOP values
+// enumerate backwards from here
+const (
+	// Must always be last. Renumber as needed.
+	GOPInvalid = -1
+)
+
 //Standard Profiles:
 //1080p60fps: 9000kbps
 //1080p30fps: 6000kbps
@@ -44,6 +52,7 @@ type VideoProfile struct {
 	AspectRatio  string
 	Format       Format
 	Profile      Profile
+	GOP          time.Duration
 }
 
 //Some sample video profiles

--- a/test.sh
+++ b/test.sh
@@ -1,56 +1,9 @@
 #Test script to run all the tests for continuous integration
 
-echo 'Testing core'
-cd core
-go test -logtostderr=true
-t1=$?
-cd ..
+set -eux
 
-echo 'Testing vidplayer'
-cd vidplayer
-go test -logtostderr=true
-t2=$?
-cd ..
+go test ./...
 
-echo 'Testing vidlistener'
-cd vidlistener
-go test -logtostderr=true
-t3=$?
-cd ..
-
-echo 'Testing Stream'
-cd stream
-go test -logtostderr=true
-t4=$?
-cd ..
-
-echo 'Testing Transcoder'
-cd transcoder
-go test -logtostderr=true
-t5=$?
-cd ..
-
-echo 'Testing Segmener'
-cd segmenter
-go test -logtostderr=true
-t6=$?
-cd ..
-
-echo 'Testing FFmpeg'
-cd ffmpeg
-go test -logtostderr=true
-t7=$?
-cd ..
-
-echo 'Testing example program'
 go run cmd/transcoding/transcoding.go transcoder/test.ts P144p30fps16x9,P240p30fps16x9 sw
-t8=$?
 
-if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0||$t8!=0))
-then
-    printf "\n\nSome Tests Failed\n\n"
-    exit -1
-else 
-    printf "\n\nAll Tests Passed\n\n"
-    exit 0
-fi
+printf "\n\nAll Tests Passed\n\n"


### PR DESCRIPTION
Adds user control over the output GOP interval.

### Changes
* Add a "GOP" field to VideoProfile in units of `time.Duration`.  8f0ad3555d9f1f385e4d17180e6cd6c0a780383d
* If fixed FPS output is used, use built-in `g` AVOption to have the encoder output keyframes based on a fixed frame interval. 8f0ad3555d9f1f385e4d17180e6cd6c0a780383d
* If passthrough FPS is used, keep track of when the next keyframe is due based on timestamps and explicitly assign frames to keyframes within LPMS. 78548c9079617ff8c6cddb4a90cb2fafe5ddf9da
* Adds an intra mode to demonstrate support for extended GOP modes. f1ca834f064f6b052fc9a48bde72aedf3024478f  
* simplify test runner 4c6d62c9f22011e48a538c46a885397b1fde475d
* Error checking for invalid GOP values. This starts at -1 and is bumped down to -2 for intra mode. This should be bumped down further if additional modes are ever added, such as source matching.