### PR TITLE
ffmpeg: Custom timestamp handling

### DIFF
--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1172,11 +1172,13 @@ func TestTranscoder_FFmpegMatching(t *testing.T) {
 	// 1 second input, N fps ( M frames; N != M for $reasons )
 	// Output set to N/2 fps . Output contains ( M / 2 ) frames
 
+	// TODO Unable to compare the frame counts in the following since diverged FPS handling from FFmpeg
+	// Even though the LPMS frame counts make sense on their own
+
 	// Other cases with audio result in frame count matching FPS
 	// 1 second input, N fps ( N frames )
 	// Output set to M fps. Output contains M frames
 
-	// TODO Unable to compare these since diverged FPS handling from from FFmpeg, Find a better way
 	// Weird framerate case
 	// 1 second input, N fps ( N frames )
 	// Output set to 123 fps. Output contains 125 frames
@@ -1280,7 +1282,7 @@ nb_read_frames=%d
 	if res.Encoded[0].Frames != 60 { //
 		t.Error("Did not get expected frame count ", res.Encoded[0].Frames)
 	}
-	//checkStatsFile(in, &out[0], res)
+	// checkStatsFile(in, &out[0], res) // TODO framecounts don't match ffmpeg
 
 	// audio + 60fps input, 123 fps output. 123 frames actual
 	in.Fname = dir + "/test-60fps.ts"
@@ -1293,7 +1295,7 @@ nb_read_frames=%d
 	if res.Encoded[0].Frames != 123 { // (FIXED) TODO Find out why this isn't 123
 		t.Error("Did not get expected frame count ", res.Encoded[0].Frames)
 	}
-	//checkStatsFile(in, &out[0], res)
+	// checkStatsFile(in, &out[0], res) // TODO framecounts don't match ffmpeg
 }
 
 func TestTranscoder_PassthroughFPS(t *testing.T) {


### PR DESCRIPTION
**Why?**
Look at #199 for details on what this PR fixes.

**What has been changed?**

* Disable check for Out-Of-Order segments
* Set uniformly-increasing monotonic PTS as the input to filtergraph (when FPS filter is used)
* Set `opaque` to original PTS
* Use original PTS rescaled to the filtergraph output-timebase to calculate the correct output PTS
  * This is done only for the first frame of the segment
  * Store the difference between the output PTS filtergraph sent for the first frame, and the calculated PTS for the first frame of the segment
  * Apply this difference on every subsequent frame (This ensures uniformly increasing output for a particular segment, but maintains the original intra-segment order)

For example see the output of the AlternatingTimestamps test case [here](https://gist.github.com/jailuthra/784cc1c30d1f0eeb44b24676f0b399b4#file-lpms_alternating_segments-txt). The segments are out of order - `1,0,3,2`. The output shows different PTS values in the order - `original_pts, rescaled_to_output, filterbuffer_output, final_calculated_pts`.

The final calculated PTS is now uniformly increasing, and maintains intra-segment ordering by being close to the rescaled value of the original input PTS.

**Testing**

* Manually tested `transcoding` binary produces usual output with correct timestamps
* Manually tested out of order segments usecase
* Modified AlternatingTimestamps unit test to run completely
* Manually tested the segments in #197 with missing frames, they work without causing drift now.
* ~~**WIP** Disabled or tweaked other failing test cases for now until the approach is verified~~
* Modified other test cases as needed, to match the new approach (some 1-on-1 pts comparisons with ffmpeg fail now but that was expected)
* ~~TODO~~ Added a custom testcase to reproduce #197 using the sample segment present in LPMS