### PR TITLE
Handle zero-frame (audio-only) segments at the start of a session

### DIFF
--- a/ffmpeg/lpms_ffmpeg.c
+++ b/ffmpeg/lpms_ffmpeg.c
@@ -273,6 +273,45 @@ handle_r2h_err:
 }
 
 //
+// Bypass Check
+// this is needed to handle streams that have first few segments that are
+// audio-only (i.e. have a video stream but no frames)
+// returns: 0 if both audio/video streams valid
+//          1 for video with 0-frame, that needs bypass
+//          <0 invalid stream(s) or internal error
+//
+int lpms_is_bypass_needed(char *fname)
+{
+  AVFormatContext *ic = NULL;
+  int ret = 0, vstream = 0, astream = 0;
+
+  ret = avformat_open_input(&ic, fname, NULL, NULL);
+  if (ret < 0) { ret = -1; goto close_format_context; }
+  ret = avformat_find_stream_info(ic, NULL);
+  if (ret < 0) { ret = -1; goto close_format_context; }
+
+  vstream = av_find_best_stream(ic, AVMEDIA_TYPE_VIDEO, -1, -1, NULL, 0);
+  astream = av_find_best_stream(ic, AVMEDIA_TYPE_AUDIO, -1, -1, NULL, 0);
+  if (vstream >= 0 && astream >= 0) {
+      if (AV_PIX_FMT_NONE == ic->streams[vstream]->codecpar->format &&
+          0 == ic->streams[vstream]->codecpar->height) {
+          // no valid pixel format and picture height => needs bypass
+          ret = 1;
+      } else {
+          // no bypass needed if video stream is valid
+          ret = 0;
+      }
+  } else {
+      // one of audio or video streams not present at all, won't bypass
+      ret = -1;
+  }
+close_format_context:
+  if (ic) avformat_close_input(&ic);
+  return ret;
+}
+
+
+//
 // Transcoder
 //
 

--- a/ffmpeg/lpms_ffmpeg.h
+++ b/ffmpeg/lpms_ffmpeg.h
@@ -54,5 +54,6 @@ int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char
 int  lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
 struct transcode_thread* lpms_transcode_new();
 void lpms_transcode_stop(struct transcode_thread* handle);
+int  lpms_is_bypass_needed(char *fname);
 
 #endif // _LPMS_FFMPEG_H_

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -784,4 +784,8 @@ func TestNvidia_SetGOPs(t *testing.T) {
 	setGops(t, Nvidia)
 }
 
+func TestNvidia_AudioOnly(t *testing.T) {
+	audioOnlySegment(t, Nvidia)
+}
+
 // XXX test bframes or delayed frames


### PR DESCRIPTION
**Why?**
For details check the audio-only bug this PR fixes #203

**How?**
We bypass the usual transcoding process for the first n-segments of a stream that do not have any frames, but do have a valid *video substream* present in the container format.
The bypassing is done by forcing the copy transcoder https://github.com/livepeer/lpms/commit/8bc28e3f702049a17c24ab2041857a47d8af51bf for such segments.

**Testing Done:**
- Manually reproduced with a failing segment from prod
- Reproduced the issue with a unit test https://github.com/livepeer/lpms/commit/c372f562194ea0c88595d7f05797f827f6ffd683
- Fixed & verified the fix for both of the above ^