### PR TITLE
ffmpeg: bypass txcoder only for mpegts

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -381,8 +381,11 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 func bypassTranscoding(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeResults, error) {
 	glog.Warningf("Input %s has audio & video streams but no video frames. Bypassing the transcoder.", input.Fname)
 	for i, p := range ps {
-		if p.Profile != (VideoProfile{}) {
-			p.Profile = (VideoProfile{})
+		if p.Profile != (VideoProfile{}) && p.Profile.Format != FormatMP4 {
+			// we only bypass when a VideoProfile is set (i.e. not a copy/drop) and output format
+			// is mpegts.
+			// FIXME: Temporary fix. The transcoder is not the place for such hacky code
+			p.Profile = VideoProfile{Name: p.Profile.Name, Format: FormatMPEGTS}
 			if "drop" != p.VideoEncoder.Name && "copy" != p.VideoEncoder.Name {
 				p.VideoEncoder = ComponentOptions{Name: "copy"}
 			}


### PR DESCRIPTION
**Why?**
Refer to https://github.com/livepeer/go-livepeer/pull/1608 for details on why this was needed.

**What?**
Ensure the bypass implemented for audio-only segments at the start of a stream only happen for MPEG-TS muxer format and help out the transcoder by passing the out format through `VideoProfile.Format`. (go-livepeer uses `.tempfile` extension because the segs might be .ts or .m4s)

**Note:** This is a temporary hack, and I want to further emphasize that the transcoder should support a Go function (that calls Cgo ffmpeg api) to *only check* whether a bypass is needed. The actual bypass logic (and what options to tweak) should be maintained upstream either in the Broadcaster code (if needed for public network) or the API product code.