### PR TITLE
ffmpeg: Throw error instead of bypassing for audio-only stream

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -1232,7 +1232,9 @@ func audioOnlySegment(t *testing.T, accel Acceleration) {
 			Accel:   accel,
 		}}
 		_, err := tc.Transcode(in, out)
-		if err != nil {
+		if i == 2 && (err == nil || err.Error() != "No video parameters found while initializing stream") {
+			t.Error("Expected to fail for audio-only segment but did not")
+		} else if i != 2 && err != nil {
 			t.Error(err)
 		}
 	}


### PR DESCRIPTION
**What is done?**
* Reverted the bypassing performed for initial segments with broken video streams.
* Retained the detection code and now throw an early error for such streams to prevent the extra-cost associated with initializing contexts for decoding.

**Why?**
The original error is not reproducible anymore, and the current state of `master` which bypasses segments altogether may cause issues with playback and is not a stable well-tested solution.