### PR TITLE
ffmpeg: Improve Cgo logging

### DIFF
--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -1,5 +1,6 @@
 #include "transcoder.h"
 #include "decoder.h"
+#include "logging.h"
 
 #include <libavutil/pixfmt.h>
 
@@ -27,19 +28,14 @@ static void send_first_pkt(struct input_ctx *ictx)
 
   int ret = avcodec_send_packet(ictx->vc, ictx->first_pkt);
   if (ret < 0) {
-    char errstr[AV_ERROR_MAX_STRING_SIZE];
-    av_strerror(ret, errstr, sizeof errstr);
-    fprintf(stderr, "Error sending flush packet : %s\n", errstr);
+    LPMS_ERR(packet_cleanup, "Error sending flush packet");
   } else ictx->sentinel_count++;
+packet_cleanup:
+  return;
 }
 
 int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt)
 {
-#define dec_err(msg) { \
-  if (!ret) ret = -1; \
-  fprintf(stderr, "dec_cleanup: "msg); \
-  goto dec_cleanup; \
-}
   int ret = 0;
 
   // Read a packet and attempt to decode it.
@@ -50,7 +46,7 @@ int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt)
     AVCodecContext *decoder = NULL;
     ret = av_read_frame(ictx->ic, pkt);
     if (ret == AVERROR_EOF) goto dec_flush;
-    else if (ret < 0) dec_err("Unable to read input\n");
+    else if (ret < 0) LPMS_ERR(dec_cleanup, "Unable to read input");
     ist = ictx->ic->streams[pkt->stream_index];
     if (ist->index == ictx->vi && ictx->vc) decoder = ictx->vc;
     else if (ist->index == ictx->ai && ictx->ac) decoder = ictx->ac;
@@ -63,7 +59,7 @@ int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt)
     }
 
     ret = lpms_send_packet(ictx, decoder, pkt);
-    if (ret < 0) dec_err("Error sending packet to decoder\n");
+    if (ret < 0) LPMS_ERR(dec_cleanup, "Error sending packet to decoder");
     ret = lpms_receive_frame(ictx, decoder, frame);
     if (ret == AVERROR(EAGAIN)) {
       // Distinguish from EAGAIN that may occur with
@@ -71,7 +67,7 @@ int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt)
       ret = lpms_ERR_PACKET_ONLY;
       break;
     }
-    else if (ret < 0) dec_err("Error receiving frame from decoder\n");
+    else if (ret < 0) LPMS_ERR(dec_cleanup, "Error receiving frame from decoder");
     break;
 
 drop_packet:
@@ -113,8 +109,6 @@ dec_flush:
     if (!ret) return ret;
   }
   return AVERROR_EOF;
-
-#undef dec_err
 }
 
 // FIXME: name me and the other function better
@@ -125,7 +119,7 @@ enum AVPixelFormat hw2pixfmt(AVCodecContext *ctx)
   for (int i = 0;; i++) {
     const AVCodecHWConfig *config = avcodec_get_hw_config(decoder, i);
     if (!config) {
-      fprintf(stderr, "Decoder %s does not support hw decoding\n", decoder->name);
+      LPMS_WARN("Decoder does not support hw decoding");
       return AV_PIX_FMT_NONE;
     }
     if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
@@ -142,17 +136,14 @@ enum AVPixelFormat hw2pixfmt(AVCodecContext *ctx)
 static enum AVPixelFormat get_hw_pixfmt(AVCodecContext *vc, const enum AVPixelFormat *pix_fmts)
 {
   AVHWFramesContext *frames;
-  int ret;
+  int ret = 0;
 
   // XXX Ideally this would be auto initialized by the HW device ctx
   //     However the initialization doesn't occur in time to set up filters
   //     So we do it here. Also see avcodec_get_hw_frames_parameters
   av_buffer_unref(&vc->hw_frames_ctx);
   vc->hw_frames_ctx = av_hwframe_ctx_alloc(vc->hw_device_ctx);
-  if (!vc->hw_frames_ctx) {
-    fprintf(stderr, "Unable to allocate hwframe context for decoding\n");
-    return AV_PIX_FMT_NONE;
-  }
+  if (!vc->hw_frames_ctx) LPMS_ERR(pixfmt_cleanup, "Unable to allocate hwframe context for decoding");
 
   frames = (AVHWFramesContext*)vc->hw_frames_ctx->data;
   frames->format = hw2pixfmt(vc);
@@ -167,10 +158,7 @@ static enum AVPixelFormat get_hw_pixfmt(AVCodecContext *vc, const enum AVPixelFo
 
   ret = av_hwframe_ctx_init(vc->hw_frames_ctx);
   if (AVERROR(ENOSYS) == ret) ret = lpms_ERR_INPUT_PIXFMT; // most likely
-  if (ret < 0) {
-    fprintf(stderr,"Unable to initialize a hardware frame pool\n");
-    return AV_PIX_FMT_NONE;
-  }
+  if (ret < 0) LPMS_ERR(pixfmt_cleanup, "Unable to initialize a hardware frame pool");
 
 /*
 fprintf(stderr, "selected format: hw %s sw %s\n",
@@ -182,16 +170,14 @@ fprintf(stderr,"possible format: %s\n", av_get_pix_fmt_name(*p));
 */
 
   return frames->format;
+
+pixfmt_cleanup:
+  return AV_PIX_FMT_NONE;
 }
 
 
 int open_audio_decoder(input_params *params, struct input_ctx *ctx)
 {
-#define ad_err(msg) { \
-  if (!ret) ret = -1; \
-  fprintf(stderr, msg); \
-  goto open_audio_err; \
-}
   int ret = 0;
   AVCodec *codec = NULL;
   AVFormatContext *ic = ctx->ic;
@@ -200,16 +186,16 @@ int open_audio_decoder(input_params *params, struct input_ctx *ctx)
   ctx->ai = av_find_best_stream(ic, AVMEDIA_TYPE_AUDIO, -1, -1, &codec, 0);
   if (ctx->da) ; // skip decoding audio
   else if (ctx->ai < 0) {
-    fprintf(stderr, "No audio stream found in input\n");
+    LPMS_INFO("No audio stream found in input");
   } else {
     AVCodecContext * ac = avcodec_alloc_context3(codec);
-    if (!ac) ad_err("Unable to alloc audio codec\n");
-    if (ctx->ac) fprintf(stderr, "Audio context already open! %p\n", ctx->ac);
+    if (!ac) LPMS_ERR(open_audio_err, "Unable to alloc audio codec");
+    if (ctx->ac) LPMS_WARN("An audio context was already open!");
     ctx->ac = ac;
     ret = avcodec_parameters_to_context(ac, ic->streams[ctx->ai]->codecpar);
-    if (ret < 0) ad_err("Unable to assign audio params\n");
+    if (ret < 0) LPMS_ERR(open_audio_err, "Unable to assign audio params");
     ret = avcodec_open2(ac, codec, NULL);
-    if (ret < 0) ad_err("Unable to open audio decoder\n");
+    if (ret < 0) LPMS_ERR(open_audio_err, "Unable to open audio decoder");
   }
 
   return 0;
@@ -217,16 +203,10 @@ int open_audio_decoder(input_params *params, struct input_ctx *ctx)
 open_audio_err:
   free_input(ctx);
   return ret;
-#undef ad_err
 }
 
 int open_video_decoder(input_params *params, struct input_ctx *ctx)
 {
-#define dd_err(msg) { \
-  if (!ret) ret = -1; \
-  fprintf(stderr, msg); \
-  goto open_decoder_err; \
-}
   int ret = 0;
   AVCodec *codec = NULL;
   AVFormatContext *ic = ctx->ic;
@@ -235,41 +215,41 @@ int open_video_decoder(input_params *params, struct input_ctx *ctx)
   ctx->vi = av_find_best_stream(ic, AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0);
   if (ctx->dv) ; // skip decoding video
   else if (ctx->vi < 0) {
-    fprintf(stderr, "No video stream found in input\n");
+    LPMS_WARN("No video stream found in input");
   } else {
     if (AV_HWDEVICE_TYPE_CUDA == params->hw_type) {
       if (AV_CODEC_ID_H264 != codec->id) {
         ret = lpms_ERR_INPUT_CODEC;
-        dd_err("Non H264 codec detected in input\n");
+        LPMS_ERR(open_decoder_err, "Non H264 codec detected in input");
       }
       AVCodec *c = avcodec_find_decoder_by_name("h264_cuvid");
       if (c) codec = c;
-      else fprintf(stderr, "Cuvid decoder not found; defaulting to software\n");
+      else LPMS_WARN("Nvidia decoder not found; defaulting to software");
       if (AV_PIX_FMT_YUV420P != ic->streams[ctx->vi]->codecpar->format &&
           AV_PIX_FMT_YUVJ420P != ic->streams[ctx->vi]->codecpar->format) {
         // TODO check whether the color range is truncated if yuvj420p is used
         ret = lpms_ERR_INPUT_PIXFMT;
-        dd_err("Non 4:2:0 pixel format detected in input\n");
+        LPMS_ERR(open_decoder_err, "Non 4:2:0 pixel format detected in input");
       }
     }
     AVCodecContext *vc = avcodec_alloc_context3(codec);
-    if (!vc) dd_err("Unable to alloc video codec\n");
+    if (!vc) LPMS_ERR(open_decoder_err, "Unable to alloc video codec");
     ctx->vc = vc;
     ret = avcodec_parameters_to_context(vc, ic->streams[ctx->vi]->codecpar);
-    if (ret < 0) dd_err("Unable to assign video params\n");
+    if (ret < 0) LPMS_ERR(open_decoder_err, "Unable to assign video params");
     vc->opaque = (void*)ctx;
     // XXX Could this break if the original device falls out of scope in golang?
     if (params->hw_type != AV_HWDEVICE_TYPE_NONE) {
       // First set the hw device then set the hw frame
       ret = av_hwdevice_ctx_create(&ctx->hw_device_ctx, params->hw_type, params->device, NULL, 0);
-      if (ret < 0) dd_err("Unable to open hardware context for decoding\n")
+      if (ret < 0) LPMS_ERR(open_decoder_err, "Unable to open hardware context for decoding")
       ctx->hw_type = params->hw_type;
       vc->hw_device_ctx = av_buffer_ref(ctx->hw_device_ctx);
       vc->get_format = get_hw_pixfmt;
     }
     vc->pkt_timebase = ic->streams[ctx->vi]->time_base;
     ret = avcodec_open2(vc, codec, NULL);
-    if (ret < 0) dd_err("Unable to open video decoder\n");
+    if (ret < 0) LPMS_ERR(open_decoder_err, "Unable to open video decoder");
   }
 
   return 0;
@@ -277,42 +257,35 @@ int open_video_decoder(input_params *params, struct input_ctx *ctx)
 open_decoder_err:
   free_input(ctx);
   return ret;
-#undef dd_err
 }
 
 int open_input(input_params *params, struct input_ctx *ctx)
 {
-#define dd_err(msg) { \
-  if (!ret) ret = -1; \
-  fprintf(stderr, msg); \
-  goto open_input_err; \
-}
   AVFormatContext *ic   = NULL;
   char *inp = params->fname;
   int ret = 0;
 
   // open demuxer
   ret = avformat_open_input(&ic, inp, NULL, NULL);
-  if (ret < 0) dd_err("demuxer: Unable to open input\n");
+  if (ret < 0) LPMS_ERR(open_input_err, "demuxer: Unable to open input");
   ctx->ic = ic;
   ret = avformat_find_stream_info(ic, NULL);
-  if (ret < 0) dd_err("Unable to find input info\n");
+  if (ret < 0) LPMS_ERR(open_input_err, "Unable to find input info");
   ret = open_video_decoder(params, ctx);
-  if (ret < 0) dd_err("Unable to open video decoder\n")
+  if (ret < 0) LPMS_ERR(open_input_err, "Unable to open video decoder")
   ret = open_audio_decoder(params, ctx);
-  if (ret < 0) dd_err("Unable to open audio decoder\n")
+  if (ret < 0) LPMS_ERR(open_input_err, "Unable to open audio decoder")
   ctx->last_frame_v = av_frame_alloc();
-  if (!ctx->last_frame_v) dd_err("Unable to alloc last_frame_v");
+  if (!ctx->last_frame_v) LPMS_ERR(open_input_err, "Unable to alloc last_frame_v");
   ctx->last_frame_a = av_frame_alloc();
-  if (!ctx->last_frame_a) dd_err("Unable to alloc last_frame_a");
+  if (!ctx->last_frame_a) LPMS_ERR(open_input_err, "Unable to alloc last_frame_a");
 
   return 0;
 
 open_input_err:
-  fprintf(stderr, "Freeing input based on OPEN INPUT error\n");
+  LPMS_INFO("Freeing input based on OPEN INPUT error");
   free_input(ctx);
   return ret;
-#undef dd_err
 }
 
 void free_input(struct input_ctx *inctx)

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -396,6 +396,24 @@ func (t *Transcoder) StopTranscoder() {
 	t.stopped = true
 }
 
+type LogLevel C.enum_LPMSLogLevel
+
+const (
+	FFLogTrace   = C.LPMS_LOG_TRACE
+	FFLogDebug   = C.LPMS_LOG_DEBUG
+	FFLogVerbose = C.LPMS_LOG_VERBOSE
+	FFLogInfo    = C.LPMS_LOG_INFO
+	FFLogWarning = C.LPMS_LOG_WARNING
+	FFLogError   = C.LPMS_LOG_ERROR
+	FFLogFatal   = C.LPMS_LOG_FATAL
+	FFLogPanic   = C.LPMS_LOG_PANIC
+	FFLogQuiet   = C.LPMS_LOG_QUIET
+)
+
+func InitFFmpegWithLogLevel(level LogLevel) {
+	C.lpms_init(C.enum_LPMSLogLevel(level))
+}
+
 func InitFFmpeg() {
-	C.lpms_init()
+	InitFFmpegWithLogLevel(FFLogWarning)
 }

--- a/ffmpeg/logging.h
+++ b/ffmpeg/logging.h
@@ -1,0 +1,22 @@
+#ifndef _LPMS_LOGGING_H_
+#define _LPMS_LOGGING_H_
+
+// LOGGING MACROS
+
+#define LPMS_ERR(label, msg) {\
+char errstr[AV_ERROR_MAX_STRING_SIZE] = {0}; \
+if (!ret) ret = AVERROR(EINVAL); \
+if (ret <-1) av_strerror(ret, errstr, sizeof errstr); \
+av_log(NULL, AV_LOG_ERROR, "ERROR: %s:%d] %s : %s\n", __FILE__, __LINE__, msg, errstr); \
+goto label; \
+}
+
+#define LPMS_WARN(msg) {\
+av_log(NULL, AV_LOG_WARNING, "WARNING: %s:%d] %s\n", __FILE__, __LINE__, msg); \
+}
+
+#define LPMS_INFO(msg) {\
+av_log(NULL, AV_LOG_INFO, "%s:%d] %s\n", __FILE__, __LINE__, msg); \
+}
+
+#endif // _LPMS_LOGGING_H_

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -78,9 +78,9 @@ struct transcode_thread {
 
 };
 
-void lpms_init()
+void lpms_init(enum LPMSLogLevel max_level)
 {
-  av_log_set_level(AV_LOG_WARNING);
+  av_log_set_level(max_level);
 }
 
 //
@@ -298,7 +298,6 @@ transcode_cleanup:
   if (ictx->vc && AV_HWDEVICE_TYPE_NONE == ictx->hw_type) avcodec_free_context(&ictx->vc);
   for (i = 0; i < nb_outputs; i++) close_output(&outputs[i]);
   return ret == AVERROR_EOF ? 0 : ret;
-#undef main_err
 }
 
 int lpms_transcode(input_params *inp, output_params *params,

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -53,7 +53,19 @@ typedef struct {
     int64_t pixels;
 } output_results;
 
-void lpms_init();
+enum LPMSLogLevel {
+  LPMS_LOG_TRACE    = AV_LOG_TRACE,
+  LPMS_LOG_DEBUG    = AV_LOG_DEBUG,
+  LPMS_LOG_VERBOSE  = AV_LOG_VERBOSE,
+  LPMS_LOG_INFO     = AV_LOG_INFO,
+  LPMS_LOG_WARNING  = AV_LOG_WARNING,
+  LPMS_LOG_ERROR    = AV_LOG_ERROR,
+  LPMS_LOG_FATAL    = AV_LOG_FATAL,
+  LPMS_LOG_PANIC    = AV_LOG_PANIC,
+  LPMS_LOG_QUIET    = AV_LOG_QUIET
+};
+
+void lpms_init(enum LPMSLogLevel max_level);
 int  lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
 struct transcode_thread* lpms_transcode_new();
 void lpms_transcode_stop(struct transcode_thread* handle);


### PR DESCRIPTION
**Why**
Clean up logging in the Cgo code (Fixes #209)

**What**
- Use ffmpeg's logging library with appropriate levels like ERROR, WARNING, INFO instead of throwing everything on stderr blindly.
- Add a well defined log prefix like `[lpms.decoder.xyz]` of the component from where the log is being emitted.
- Does *not* add any extra INFO logs, will do it separately the next time I go around debugging something and need to trace out the location in the transcoder pipeline

**Notes**
Commit(s) to be applied on top of #212