### PR TITLE
decoder: Error out on segments with no keyframe packets

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -1243,3 +1243,46 @@ func audioOnlySegment(t *testing.T, accel Acceleration) {
 func TestTranscoder_AudioOnly(t *testing.T) {
 	audioOnlySegment(t, Software)
 }
+
+/*
+func noKeyframeSegment(t *testing.T, accel Acceleration) {
+	// Reproducing #219
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+		cp "$1"/../transcoder/kryp-*.ts .
+
+    # verify no keyframes in kryp-2.ts but there in kryp-1.ts
+    ffprobe -select_streams v -show_streams -show_packets kryp-1.ts | grep flags=K | wc -l | grep 1
+    ffprobe -select_streams v -show_streams -show_packets kryp-2.ts | grep flags=K | wc -l | grep 0
+  `
+	run(cmd)
+
+	tc := NewTranscoder()
+	prof := P144p30fps16x9
+	for i := 1; i <= 2; i++ {
+		in := &TranscodeOptionsIn{
+			Fname: fmt.Sprintf("%s/kryp-%d.ts", dir, i),
+			Accel: accel,
+		}
+		out := []TranscodeOptions{{
+			Oname:   fmt.Sprintf("%s/out%d.ts", dir, i),
+			Profile: prof,
+			Accel:   accel,
+		}}
+		_, err := tc.Transcode(in, out)
+		if i == 2 && (err == nil || err.Error() != "No keyframes in input") {
+			t.Error("Expected to fail for no keyframe segment but did not")
+		} else if i != 2 && err != nil {
+			t.Error(err)
+		}
+	}
+	tc.StopTranscoder()
+
+}
+
+func TestTranscoder_NoKeyframe(t *testing.T) {
+	noKeyframeSegment(t, Software)
+}
+*/

--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -22,16 +22,17 @@ static int lpms_receive_frame(struct input_ctx *ictx, AVCodecContext *dec, AVFra
     return ret;
 }
 
-static void send_first_pkt(struct input_ctx *ictx)
+static int send_first_pkt(struct input_ctx *ictx)
 {
-  if (ictx->flushed || !ictx->first_pkt) return;
+  if (ictx->flushed) return 0;
+  if (!ictx->first_pkt) return -1;
 
   int ret = avcodec_send_packet(ictx->vc, ictx->first_pkt);
   if (ret < 0) {
     LPMS_ERR(packet_cleanup, "Error sending flush packet");
   } else ictx->sentinel_count++;
 packet_cleanup:
-  return;
+  return ret;
 }
 
 int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt)
@@ -88,9 +89,13 @@ dec_flush:
   // get back all sent frames, or we've made SENTINEL_MAX attempts to retrieve
   // buffered frames with no success.
   // TODO this is unnecessary for SW decoding! SW process should match audio
-  if (ictx->vc) {
+  if (ictx->vc && !ictx->flushed && ictx->pkt_diff > 0) {
     ictx->flushing = 1;
-    send_first_pkt(ictx);
+    ret = send_first_pkt(ictx);
+    if (ret == -1) {
+      ictx->flushed = 1;
+      return lpms_ERR_INPUT_NOKF;
+    }
     ret = lpms_receive_frame(ictx, ictx->vc, frame);
     pkt->stream_index = ictx->vi;
     // Keep flushing if we haven't received all frames back but stop after SENTINEL_MAX tries.

--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -38,6 +38,7 @@ func error_map() map[int]error {
 		{code: C.lpms_ERR_OUTPUTS, desc: "Too many outputs"},
 		{code: C.lpms_ERR_DTS, desc: "Segment out of order"},
 		{code: C.lpms_ERR_INPUT_CODEC, desc: "Unsupported input codec"},
+		{code: C.lpms_ERR_INPUT_NOKF, desc: "No keyframes in input"},
 	}
 	for _, v := range lpmsErrors {
 		m[int(v.code)] = errors.New(v.desc)

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -788,4 +788,10 @@ func TestNvidia_AudioOnly(t *testing.T) {
 	audioOnlySegment(t, Nvidia)
 }
 
+/*
+func TestNvidia_NoKeyframe(t *testing.T) {
+	noKeyframeSegment(t, Nvidia)
+}
+*/
+
 // XXX test bframes or delayed frames

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -10,6 +10,7 @@
 // Not great to appropriate internal API like this...
 const int lpms_ERR_INPUT_PIXFMT = FFERRTAG('I','N','P','X');
 const int lpms_ERR_INPUT_CODEC = FFERRTAG('I','N','P','C');
+const int lpms_ERR_INPUT_NOKF = FFERRTAG('I','N','K','F');
 const int lpms_ERR_FILTERS = FFERRTAG('F','L','T','R');
 const int lpms_ERR_PACKET_ONLY = FFERRTAG('P','K','O','N');
 const int lpms_ERR_FILTER_FLUSHED = FFERRTAG('F','L','F','L');
@@ -193,7 +194,9 @@ int transcode(struct transcode_thread *h,
     if (ret == AVERROR_EOF) break;
                             // Bail out on streams that appear to be broken
     else if (lpms_ERR_PACKET_ONLY == ret) ; // keep going for stream copy
-    else if (ret < 0) LPMS_ERR(transcode_cleanup, "Could not decode; stopping");
+    else if (lpms_ERR_INPUT_NOKF == ret) {
+      LPMS_ERR(transcode_cleanup, "Could not decode; No keyframes in input");
+    } else if (ret < 0) LPMS_ERR(transcode_cleanup, "Could not decode; stopping");
     ist = ictx->ic->streams[ipkt.stream_index];
     has_frame = lpms_ERR_PACKET_ONLY != ret;
 

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -9,6 +9,7 @@
 // LPMS specific errors
 extern const int lpms_ERR_INPUT_PIXFMT;
 extern const int lpms_ERR_INPUT_CODEC;
+extern const int lpms_ERR_INPUT_NOKF;
 extern const int lpms_ERR_FILTERS;
 extern const int lpms_ERR_PACKET_ONLY;
 extern const int lpms_ERR_FILTER_FLUSHED;


### PR DESCRIPTION
**Why?**
The video decoder currently gets stuck in an infinite loop while flushing if the input segment does not contain any keyframes, as it uses the first keyframe packet to flush the decoder buffer.

**What?**
If no keyframe packet is found after reading and sending all packets to the decoder, return an explicit error and don't try to flush.

**Testing**
- [x] Manually tested on a segment with no keyframes
- [x] Existing unit test suite works
- [x] Added a commented out test case for segment with no keyframes

**Fixes**
Fixes #219 
