### PR TITLE
decoder: update sentinel counter even for bad packets

### DIFF
--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -25,12 +25,13 @@ static int lpms_receive_frame(struct input_ctx *ictx, AVCodecContext *dec, AVFra
 static int send_first_pkt(struct input_ctx *ictx)
 {
   if (ictx->flushed) return 0;
-  if (!ictx->first_pkt) return -1;
+  if (!ictx->first_pkt) return lpms_ERR_INPUT_NOKF;
 
   int ret = avcodec_send_packet(ictx->vc, ictx->first_pkt);
+  ictx->sentinel_count++;
   if (ret < 0) {
     LPMS_ERR(packet_cleanup, "Error sending flush packet");
-  } else ictx->sentinel_count++;
+  }
 packet_cleanup:
   return ret;
 }
@@ -92,18 +93,18 @@ dec_flush:
   if (ictx->vc && !ictx->flushed && ictx->pkt_diff > 0) {
     ictx->flushing = 1;
     ret = send_first_pkt(ictx);
-    if (ret == -1) {
+    if (ret < 0) {
       ictx->flushed = 1;
-      return lpms_ERR_INPUT_NOKF;
+      return ret;
     }
     ret = lpms_receive_frame(ictx, ictx->vc, frame);
     pkt->stream_index = ictx->vi;
     // Keep flushing if we haven't received all frames back but stop after SENTINEL_MAX tries.
     if (ictx->pkt_diff != 0 && ictx->sentinel_count <= SENTINEL_MAX && (!ret || ret == AVERROR(EAGAIN))) {
-        return 0; // ignore actual return value and keep flushing
+      return 0; // ignore actual return value and keep flushing
     } else {
-        ictx->flushed = 1;
-        if (!ret) return ret;
+      ictx->flushed = 1;
+      if (!ret) return ret;
     }
   }
   // Flush audio decoder.


### PR DESCRIPTION
**What?**
Fix the incrementing logic of the flush "sentinel" packet counter. Previously that counter was not updated if FFmpeg threw an error for the packet, which lead to an infinite loop.

**Why?**
Fixes #222 

