### PR TITLE
ffmpeg: separate non-retryable errors

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -1232,8 +1232,8 @@ func audioOnlySegment(t *testing.T, accel Acceleration) {
 			Accel:   accel,
 		}}
 		_, err := tc.Transcode(in, out)
-		if i == 2 && (err == nil || err.Error() != "No video parameters found while initializing stream") {
-			t.Error("Expected to fail for audio-only segment but did not")
+		if i == 2 && (err == nil || err.Error() != "TranscoderInvalidVideo") {
+			t.Errorf("Expected to fail for audio-only segment but did not, instead got err=%v", err)
 		} else if i != 2 && err != nil {
 			t.Error(err)
 		}

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -21,10 +21,12 @@ import "C"
 var ErrTranscoderRes = errors.New("TranscoderInvalidResolution")
 var ErrTranscoderHw = errors.New("TranscoderInvalidHardware")
 var ErrTranscoderInp = errors.New("TranscoderInvalidInput")
+var ErrTranscoderVid = errors.New("TranscoderInvalidVideo")
 var ErrTranscoderStp = errors.New("TranscoderStopped")
 var ErrTranscoderFmt = errors.New("TranscoderUnrecognizedFormat")
 var ErrTranscoderPrf = errors.New("TranscoderUnrecognizedProfile")
 var ErrTranscoderGOP = errors.New("TranscoderInvalidGOP")
+var ErrTranscoderDev = errors.New("TranscoderIncompatibleDevices")
 
 type Acceleration int
 
@@ -144,7 +146,7 @@ func configAccel(inAcc, outAcc Acceleration, inDev, outDev string) (string, stri
 		case Nvidia:
 			// If we encode on a different device from decode then need to transfer
 			if outDev != "" && outDev != inDev {
-				return "", "", ErrTranscoderInp // XXX not allowed
+				return "", "", ErrTranscoderDev // XXX not allowed
 			}
 			return "h264_nvenc", "scale_cuda", nil
 		}
@@ -195,7 +197,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 			t.started = true
 		} else {
 			// Audio-only segment, fail fast right here as we cannot handle them nicely
-			return nil, errors.New("No video parameters found while initializing stream")
+			return nil, ErrTranscoderVid
 		}
 	}
 	params := make([]C.output_params, len(ps))

--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-var LPMSErrors = []struct {
+var lpmsErrors = []struct {
 	Code C.int
 	Desc string
 }{
@@ -40,7 +40,7 @@ func error_map() map[int]error {
 	}
 
 	// Add in LPMS specific errors
-	for _, v := range LPMSErrors {
+	for _, v := range lpmsErrors {
 		m[int(v.Code)] = errors.New(v.Desc)
 	}
 
@@ -48,6 +48,34 @@ func error_map() map[int]error {
 }
 
 var ErrorMap = error_map()
+
+func non_retryable_errs() []string {
+	errs := []string{}
+	// Add in Cgo LPMS specific errors
+	for _, v := range lpmsErrors {
+		errs = append(errs, v.Desc)
+	}
+	// Add in internal FFmpeg errors
+	// from https://ffmpeg.org/doxygen/trunk/error_8c_source.html#l00034
+	ffmpegErrors := []string{
+		"Decoder not found", "Demuxer not found", "Encoder not found",
+		"Muxer not found", "Option not found", "Invalid argument",
+	}
+	for _, v := range ffmpegErrors {
+		errs = append(errs, v)
+	}
+	// Add in ffmpeg.go transcoder specific errors
+	transcoderErrors := []error{
+		ErrTranscoderRes, ErrTranscoderVid, ErrTranscoderFmt,
+		ErrTranscoderPrf, ErrTranscoderGOP, ErrTranscoderDev,
+	}
+	for _, v := range transcoderErrors {
+		errs = append(errs, v.Error())
+	}
+	return errs
+}
+
+var NonRetryableErrs = non_retryable_errs()
 
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // Corbatto (luca@corbatto.de)


### PR DESCRIPTION
**Why?**
Needed for https://github.com/livepeer/go-livepeer/issues/1774

**What?**
Add more errors, and separate out the "Non Retryable" category to be used by the B. Updated list of errors includes:

- All LPMS C-module errors
- A subset of LPMS Go-module errors around bad input/parameters
- A subset of [internal ffmpeg errors](https://ffmpeg.org/doxygen/trunk/error_8c_source.html#l00034) that may get surfaced back to the B
