### PR TITLE
encoder: set output framerate correctly for passthrough

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -788,6 +788,10 @@ func TestNvidia_AudioOnly(t *testing.T) {
 	audioOnlySegment(t, Nvidia)
 }
 
+func TestNvidia_OutputFPS(t *testing.T) {
+	outputFPS(t, Nvidia)
+}
+
 /*
 func TestNvidia_NoKeyframe(t *testing.T) {
 	noKeyframeSegment(t, Nvidia)

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -24,9 +24,9 @@ if [ ! -e "$HOME/x264/x264" ]; then
 fi
 
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
-  git clone https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
+  git clone https://github.com/livepeer/FFmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
-  git checkout 3ea705767720033754e8d85566460390191ae27d
+  git checkout livepeer
   ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gnutls --enable-gpl --enable-static
   make
   make install

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -26,7 +26,7 @@ fi
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
   git clone https://github.com/livepeer/FFmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
-  git checkout livepeer
+  git checkout 1fdf06e14239e1aaa9ddfb648fa374ca3cb1b269
   ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gnutls --enable-gpl --enable-static
   make
   make install


### PR DESCRIPTION
**Why?**
Needed for #232 

**What's changed?**
- Ensure that output's AVStream and AVCodec have the correct framerate value when using passthrough (i.e. octx->fps = 0) https://github.com/livepeer/lpms/pull/229/commits/3b5689d177504c0f47bba2c04e5d8780e9bb68e4
- Update ffmpeg to include a cherry-picked bugfix that ensures that NVENC respects the `AVCodec->framerate` value we've set. https://github.com/livepeer/FFmpeg/pull/2

**Testing**
- Unit test introduced in https://github.com/livepeer/lpms/pull/229/commits/700787e6d8ca1ba3b008180130033a9708dc08d5 fails before the changes in the PR, but passes after the changes in the PR
(manually tested on my GTX 1060 and livepeer's GTX 1070)

**Note To Reviewer**
- A manual `git checkout master && git rebase jai/streamfps && git merge` is preferred to retain the commit-ID used in the mod update in https://github.com/livepeer/go-livepeer/pull/1862
