### PR TITLE
Change signature of `HasZeroVideoFrame` and `HasZeroVideoFrameBytes`

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -84,21 +84,21 @@ type TranscodeResults struct {
 	Encoded []MediaInfo
 }
 
-// HasZeroVideoFrame opens video file and returns 1 if it has video stream with 0-frame
-func HasZeroVideoFrame(fname string) int {
+// HasZeroVideoFrame opens video file and returns true if it has video stream with 0-frame
+func HasZeroVideoFrame(fname string) bool {
 	cfname := C.CString(fname)
 	defer C.free(unsafe.Pointer(cfname))
-	return int(C.lpms_is_bypass_needed(cfname))
+	return int(C.lpms_is_bypass_needed(cfname)) == 1
 }
 
-// HasZeroVideoFrameBytes  opens video and returns 1 if it has video stream with 0-frame
-func HasZeroVideoFrameBytes(data []byte) (int, error) {
+// HasZeroVideoFrameBytes  opens video and returns true if it has video stream with 0-frame
+func HasZeroVideoFrameBytes(data []byte) (bool, error) {
 	if len(data) == 0 {
-		return 0, ErrEmptyData
+		return false, ErrEmptyData
 	}
 	or, ow, err := os.Pipe()
 	if err != nil {
-		return -1, err
+		return false, err
 	}
 	fname := fmt.Sprintf("pipe:%d", or.Fd())
 	cfname := C.CString(fname)
@@ -116,7 +116,7 @@ func HasZeroVideoFrameBytes(data []byte) (int, error) {
 	}()
 	bres := int(C.lpms_is_bypass_needed(cfname))
 	<-done
-	return bres, nil
+	return bres == 1, nil
 }
 
 func RTMPToHLS(localRTMPUrl string, outM3U8 string, tmpl string, seglen_secs string, seg_start int) error {

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1567,8 +1567,8 @@ func TestTranscoder_ZeroFrame(t *testing.T) {
 	}
 	fname := path.Join(wd, "..", "data", "zero-frame.ts")
 	res := HasZeroVideoFrame(fname)
-	if res != 1 {
-		t.Errorf("Expecting 1, got %d fname=%s", res, fname)
+	if res != true {
+		t.Errorf("Expecting true, got %v fname=%s", res, fname)
 	}
 	data, err := ioutil.ReadFile(fname)
 	if err != nil {
@@ -1578,8 +1578,8 @@ func TestTranscoder_ZeroFrame(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if res != 1 {
-		t.Errorf("Expecting 1, got %d fname=%s", res, fname)
+	if res != true {
+		t.Errorf("Expecting true, got %v fname=%s", res, fname)
 	}
 	res, err = HasZeroVideoFrameBytes(nil)
 	if err != ErrEmptyData {
@@ -1587,7 +1587,7 @@ func TestTranscoder_ZeroFrame(t *testing.T) {
 	}
 	fname = path.Join(wd, "..", "data", "bunny.mp4")
 	res = HasZeroVideoFrame(fname)
-	if res != 0 {
-		t.Errorf("Expecting 0, got %d fname=%s", res, fname)
+	if res != false {
+		t.Errorf("Expecting false, got %v fname=%s", res, fname)
 	}
 }


### PR DESCRIPTION
change signature of `HasZeroVideoFrame` and `HasZeroVideoFrameBytes`
to return boolean instead of integer