### PR TITLE
ffmpeg: Enable B-frames with GPU encoding

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -950,11 +950,6 @@ func encodingProfiles(t *testing.T, accel Acceleration) {
 		ffprobe -loglevel warning -show_streams out_main.mp4 | grep has_b_frames=2
 		ffprobe -loglevel warning -show_streams out_high.mp4 | grep has_b_frames=2
 	`
-	// TODO: Only CPU encoder seems to use B frames by default, check if we can enable them for NVIDIA
-	if accel == Software {
-		run(cmd)
-	}
-
 	// Interlaced Input with Constrained Profiles
 	cmd = `
 		ffmpeg -i test.ts -vf "tinterlace=5" -c:v libx264 -flags +ilme+ildct -x264opts bff=1 -c:a copy test_interlaced.ts

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -347,8 +347,11 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 				"forced-idr": "1",
 			}
 			switch p.Profile.Profile {
-			case ProfileH264Baseline, ProfileH264Main, ProfileH264High:
+			case ProfileH264Baseline:
 				p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]
+			case ProfileH264Main, ProfileH264High:
+				p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]
+				p.VideoEncoder.Opts["bf"] = "3"
 			case ProfileH264ConstrainedHigh:
 				p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]
 				p.VideoEncoder.Opts["bf"] = "0"


### PR DESCRIPTION
**Why?**
Fixes #238 

By default our GPU encoder `nvenc` does not enable B-frames unless explictly set via the ffmpeg `-bf` flag - i.e currently the GOP of nvenc output looks like `IPPPPP...PPI` regardless of the selected encoding profile, because `-bf=0` by default for nvenc.

This is different from our CPU encoder `x264`, which has the corresponding internal flag [set to `3`](https://gist.github.com/newfront/875122#file-x264-encoding-options-L134 ) by default. This leads to GOPs with (at max) 3 B-frames between any two P-frames `I..PBBBP..I` if the user selected Main/High encoding profile.

We'd like the GPU encoded output to be similar to the CPU encoded one.

**What has changed?**

This patch explicitly sets the ffmpeg flag `-bf=3` for Main/High encoding profile - fixing those profiles' output when encoded with GPU.

**Testing**
Enable the previously disabled unit test to ensure B-frames are present in the encoded output from the GPU.
(tested locally on a GTX 1060)
```bash
╰─ go test -v -tags nvidia -run TestNvidia_EncoderProfile
=== RUN   TestNvidia_EncoderProfiles
[aac @ 0x7f86f4cfc700] 2 frames left in the queue on closing
[aac @ 0x7f86f4860980] 2 frames left in the queue on closing
[aac @ 0x7f86f4a5f940] 2 frames left in the queue on closing
[aac @ 0x7f86f4a8ba80] 2 frames left in the queue on closing
[aac @ 0x7f86f44dd200] 2 frames left in the queue on closing
[aac @ 0x7f86f476e400] 2 frames left in the queue on closing
--- PASS: TestNvidia_EncoderProfiles (5.65s)
PASS
ok      github.com/livepeer/lpms/ffmpeg 5.773s
```