### PR TITLE
fix HasZeroVideoFrameBytes for long segments

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -103,19 +103,13 @@ func HasZeroVideoFrameBytes(data []byte) (bool, error) {
 	fname := fmt.Sprintf("pipe:%d", or.Fd())
 	cfname := C.CString(fname)
 	defer C.free(unsafe.Pointer(cfname))
-	done := make(chan struct{})
 	go func() {
-		var err2 error
 		br := bytes.NewReader(data)
-		_, err2 = io.Copy(ow, br)
-		if err2 != nil {
-			glog.Errorf("Error sending data to lpms_is_bypass_needed function err=%v", err2)
-		}
+		io.Copy(ow, br)
 		ow.Close()
-		done <- struct{}{}
 	}()
 	bres := int(C.lpms_is_bypass_needed(cfname))
-	<-done
+	ow.Close()
 	return bres == 1, nil
 }
 

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -1581,7 +1581,7 @@ func TestTranscoder_ZeroFrame(t *testing.T) {
 	if res != true {
 		t.Errorf("Expecting true, got %v fname=%s", res, fname)
 	}
-	res, err = HasZeroVideoFrameBytes(nil)
+	_, err = HasZeroVideoFrameBytes(nil)
 	if err != ErrEmptyData {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -1589,5 +1589,16 @@ func TestTranscoder_ZeroFrame(t *testing.T) {
 	res = HasZeroVideoFrame(fname)
 	if res != false {
 		t.Errorf("Expecting false, got %v fname=%s", res, fname)
+	}
+}
+
+func TestTranscoder_ZeroFrameLongBadSegment(t *testing.T) {
+	badSegment := make([]byte, 16*1024*1024)
+	res, err := HasZeroVideoFrameBytes(badSegment)
+	if err != nil {
+		t.Error(err)
+	}
+	if res {
+		t.Errorf("Expecting false, got %v", res)
 	}
 }


### PR DESCRIPTION
ffmpeg doesn't close pipes, and when opening stream
doesn't read all the data - so `io.Copy` was waiting
forever.