### PR TITLE
ci: Fix breaking builds due to debian bullseye release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/livepeer/lpms
     docker:
-      - image: "circleci/golang:1.15.5"
+      - image: "circleci/golang:1.15.15"
         environment:
           GOROOT: /usr/local/go
           PKG_CONFIG_PATH: "/home/circleci/compiled/lib/pkgconfig"


### PR DESCRIPTION
New debian release (bullseye) [broke our CI pipeline](https://app.circleci.com/pipelines/github/livepeer/lpms/202/workflows/e210044f-b441-4b05-9960-ef6403e35723/jobs/640), which is still using the previous debian release (buster).

One solution is to [edit the `apt-get update` command](https://stackoverflow.com/questions/68802802/repository-http-security-debian-org-debian-security-buster-updates-inrelease) in the original script. But turns out the latest golang v1.15 image by CircleCI `circleci/golang:1.15.15` is (presumably) already on bullseye, and works without tweaking the apt update process.