### PR TITLE
Use static inline instead of inline

### DIFF
--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -57,7 +57,7 @@ int open_audio_decoder(input_params *params, struct input_ctx *ctx);
 void free_input(struct input_ctx *inctx);
 
 // Utility functions
-inline int is_flush_frame(AVFrame *frame)
+static inline int is_flush_frame(AVFrame *frame)
 {
   return -1 == frame->pts;
 }

--- a/ffmpeg/filter.h
+++ b/ffmpeg/filter.h
@@ -76,15 +76,15 @@ int filtergraph_read(struct input_ctx *ictx, struct output_ctx *octx, struct fil
 void free_filter(struct filter_ctx *filter);
 
 // UTILS
-inline int is_copy(char *encoder) {
+static inline int is_copy(char *encoder) {
   return encoder && !strcmp("copy", encoder);
 }
 
-inline int is_drop(char *encoder) {
+static inline int is_drop(char *encoder) {
   return !encoder || !strcmp("drop", encoder) || !strcmp("", encoder);
 }
 
-inline int needs_decoder(char *encoder) {
+static inline int needs_decoder(char *encoder) {
   // Checks whether the given "encoder" depends on having a decoder.
   // Do this by enumerating special cases that do *not* need encoding
   return !(is_copy(encoder) || is_drop(encoder));


### PR DESCRIPTION
I ran into 'undefined reference' error when trying to launch debugging from VS Code and GoLand. The reason is that `inline` specifier without `static` not always results in function inlining, and behavior is not consistent across C compilers and C standards. It can be reproduced like that:
````
CGO_CFLAGS="-std=gnu17" go build -gcflags=all="-N -l" cmd/scenedetection/scenedetection.go
````
It's hard to pinpoint exactly which C compiler settings plain `go build` uses, so I'm not sure why it works fine, probably because of C compiler and optimization flags combination. I added `static` specifier to all inline functions, which should produce intended compiler behavior.