### PR TITLE
Do not link GnuTLS library

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -20,7 +20,7 @@ import (
 	pb "github.com/livepeer/lpms/ffmpeg/proto"
 )
 
-// #cgo pkg-config: libavformat libavfilter libavcodec libavutil libswscale gnutls
+// #cgo pkg-config: libavformat libavfilter libavcodec libavutil libswscale
 // #include <stdlib.h>
 // #include "transcoder.h"
 // #include "extras.h"

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -37,7 +37,7 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
 
   git checkout 682c4189d8364867bcc49f9749e04b27dc37cded 
 
-  ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gnutls --enable-gpl --enable-static
+  ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gpl --enable-static
   make
   make install
 fi


### PR DESCRIPTION
Removes gnutls from list of dependencies.
Not need because we're [removing](https://github.com/livepeer/go-livepeer/commit/62d28bf6c59f58eba62fcec8f32fae9721edee30) http and https protocols from ffmpeg build.
