### PR TITLE
transmuxing: skip packets with same timestamp

### DIFF
--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -36,13 +36,14 @@ struct input_ctx {
 
   // transmuxing specific fields:
   // last non-zero duration
-  int64_t last_duration;
+  int64_t last_duration[MAX_OUTPUT_SIZE];
+  // keep track of last dts in each stream.
+  // used while transmuxing, to skip packets with invalid dts.
+  int64_t last_dts[MAX_OUTPUT_SIZE];
   //
-  int64_t last_dts;
+  int64_t dts_diff[MAX_OUTPUT_SIZE];
   //
-  int64_t dts_diff;
-  //
-  int discontinuity;
+  int discontinuity[MAX_OUTPUT_SIZE];
   // Transmuxing mode. Close output in lpms_transcode_stop instead of
   // at the end of lpms_transcode call.
   int transmuxing;

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -58,6 +58,7 @@ typedef struct {
 #define MAX_CLASSIFY_SIZE 10
 #define LVPDNN_FILTER_NAME "lvpdnn"
 #define LVPDNN_FILTER_META "lavfi.lvpdnn.text"
+#define MAX_OUTPUT_SIZE 10
 
 typedef struct {
     char *modelpath;

--- a/ffmpeg/transmuxer_test.go
+++ b/ffmpeg/transmuxer_test.go
@@ -119,7 +119,7 @@ func TestTransmuxer_Discontinuity(t *testing.T) {
 	tc.StopTranscoder()
 	cmd = `
     ffprobe -loglevel warning -select_streams v -count_frames -show_streams out.mp4 | grep nb_read_frames=960
-    ffprobe -loglevel warning -select_streams v -count_frames -show_streams -show_frames out.mp4 | grep pkt_pts=1441787
+    ffprobe -loglevel warning -select_streams v -count_frames -show_streams -show_frames out.mp4 | grep pkt_pts=1441410
   `
 	run(cmd)
 }

--- a/ffmpeg/transmuxer_test.go
+++ b/ffmpeg/transmuxer_test.go
@@ -119,7 +119,7 @@ func TestTransmuxer_Discontinuity(t *testing.T) {
 	tc.StopTranscoder()
 	cmd = `
     ffprobe -loglevel warning -select_streams v -count_frames -show_streams out.mp4 | grep nb_read_frames=960
-    ffprobe -loglevel warning -select_streams v -count_frames -show_streams -show_frames out.mp4 | grep pkt_pts=1441410
+    ffprobe -loglevel warning -select_streams v -count_frames -show_streams -show_frames out.mp4 | grep pkt_pts=1441787
   `
 	run(cmd)
 }


### PR DESCRIPTION
We have case where source segment has two audio packets with the same timestamp. This isn't allowed and FFmpeg returns error in the process of transmuxing.
This PR skips such packets.

Fixes https://github.com/livepeer/internal-project-tracking/issues/171

