### PR TITLE
fix segmenter test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: "Build FFMpeg"
           command: |
             sudo apt-get update
-            sudo apt-get install -y autoconf build-essential pkg-config autoconf gnutls-dev zlib1g-dev netcat-openbsd xxd
+            sudo apt-get install -y autoconf build-essential pkg-config autoconf gnutls-dev zlib1g-dev netcat-openbsd xxd clang
             bash ./install_ffmpeg.sh
 
       - save_cache:

--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -20,14 +20,14 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/livepeer/lpms/ffmpeg"
-	"github.com/livepeer/lpms/stream"
-	"github.com/livepeer/lpms/vidplayer"
-	"github.com/livepeer/m3u8"
 	"github.com/livepeer/joy4/av"
 	"github.com/livepeer/joy4/av/avutil"
 	"github.com/livepeer/joy4/format"
 	"github.com/livepeer/joy4/format/rtmp"
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/lpms/vidplayer"
+	"github.com/livepeer/m3u8"
 )
 
 type TestStream struct{}
@@ -60,6 +60,12 @@ func (s *TestStream) ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) (
 				dst.WriteTrailer()
 				eof <- struct{}{}
 			}
+			// this sends data through TCP connection
+			// during the process OS tries to negotiate bigger TCP windows
+			// and that leads to connection being reset and unit test fails
+			// because of that
+			// so slow down transfer a bit to fix this
+			time.Sleep(time.Millisecond)
 			dst.WritePacket(pkt)
 		}
 	}(eof)


### PR DESCRIPTION
Turned out when test function pumps data to TCP connection too fast it leads to that connection being reset.
Add small delay to that test function to slow down data transfer and that fixed issue.
