### PR TITLE
fix middle pixel format changing issue

### DIFF
--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -47,6 +47,9 @@ struct input_ctx {
   // Transmuxing mode. Close output in lpms_transcode_stop instead of
   // at the end of lpms_transcode call.
   int transmuxing;
+  // In HW transcoding, demuxer is opened once and used,
+  // so it is necessary to check whether the input pixel format does not change in the middle.
+  enum AVPixelFormat last_format;
 };
 
 // Exported methods

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -800,6 +800,10 @@ func TestNvidia_NonMonotonicAudioSegment(t *testing.T) {
 	nonMonotonicAudioSegment(t, Nvidia)
 }
 
+func TestNvidia_DiscontinuityPixelFormat(t *testing.T) {
+	discontinuityPixelFormatSegment(t, Nvidia)
+}
+
 /*
 func TestNvidia_DetectionFreq(t *testing.T) {
 	detectionFreq(t, Nvidia)

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -152,6 +152,7 @@ int transcode(struct transcode_thread *h,
       free_input(&h->ictx);
       ret = open_input(inp, &h->ictx);
       if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to reopen video demuxer for HW decoding");
+      reopen_decoders = 0;
     }
   }
 

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -148,7 +148,10 @@ int transcode(struct transcode_thread *h,
     else if (ictx->ic->streams[ictx->vi]->codecpar->format != ictx->last_format) {
       LPMS_WARN("Input pixel format has been changed in the middle.");
       ictx->last_format = ictx->ic->streams[ictx->vi]->codecpar->format;
-      // free and reopen demuxer
+      // if the decoder is not re-opened when the video pixel format is changed,
+      // the decoder tries HW decoding with the video context initialized to a pixel format different from the input one.
+      // to handle a change in the input pixel format,
+      // we close the demuxer and re-open the decoder by calling open_input().
       free_input(&h->ictx);
       ret = open_input(inp, &h->ictx);
       if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to reopen video demuxer for HW decoding");

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -142,6 +142,19 @@ int transcode(struct transcode_thread *h,
     ret = avio_open(&ictx->ic->pb, inp->fname, AVIO_FLAG_READ);
     if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to reopen file");
   } else reopen_decoders = 0;
+
+  if (AV_HWDEVICE_TYPE_CUDA == ictx->hw_type && ictx->vi >= 0) {
+    if (ictx->last_format == AV_PIX_FMT_NONE) ictx->last_format = ictx->ic->streams[ictx->vi]->codecpar->format;
+    else if (ictx->ic->streams[ictx->vi]->codecpar->format != ictx->last_format) {
+      LPMS_WARN("Input pixel format has been changed in the middle.");
+      ictx->last_format = ictx->ic->streams[ictx->vi]->codecpar->format;
+      // free and reopen demuxer
+      free_input(&h->ictx);
+      ret = open_input(inp, &h->ictx);
+      if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to reopen video demuxer for HW decoding");
+    }
+  }
+
   if (reopen_decoders) {
     // XXX check to see if we can also reuse decoder for sw decoding
     if (AV_HWDEVICE_TYPE_CUDA != ictx->hw_type) {
@@ -430,6 +443,8 @@ struct transcode_thread* lpms_transcode_new() {
   struct transcode_thread *h = malloc(sizeof (struct transcode_thread));
   if (!h) return NULL;
   memset(h, 0, sizeof *h);
+  // initialize video stream pixel format.
+  h->ictx.last_format = AV_PIX_FMT_NONE;
   // keep track of last dts in each stream.
   // used while transmuxing, to skip packets with invalid dts.
   for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -30,7 +30,7 @@ if [ ! -e "$HOME/x264/x264" ]; then
   git clone http://git.videolan.org/git/x264.git "$HOME/x264"
   cd "$HOME/x264"
   # git master as of this writing
-  git checkout e0eebeeeddf863f72da0232f9dddc05200340560
+  git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
   ./configure --prefix="$HOME/compiled" --enable-pic --enable-static
   make
   make install-lib-static
@@ -65,7 +65,7 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
   git clone https://github.com/livepeer/FFmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
 
-  git checkout 682c4189d8364867bcc49f9749e04b27dc37cded 
+  git checkout e0eebeeeddf863f72da0232f9dddc05200340560 
 
   ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gpl --enable-static $EXTRA_FFMPEG_FLAGS
   make

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -30,7 +30,7 @@ if [ ! -e "$HOME/x264/x264" ]; then
   git clone http://git.videolan.org/git/x264.git "$HOME/x264"
   cd "$HOME/x264"
   # git master as of this writing
-  git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
+  git checkout e0eebeeeddf863f72da0232f9dddc05200340560
   ./configure --prefix="$HOME/compiled" --enable-pic --enable-static
   make
   make install-lib-static


### PR DESCRIPTION
A follow up to #271.

In HW transcoding, demuxer is opened once and used, so it is necessary to check whether the input pixel format does not change in the middle. If a change is detected, free the input_ctx and reopen the demuxer again.

test 

```
 go test -run TestTranscoder_DiscontinuityPixelFormat ./ffmpeg
 go test --tags=nvidia -run TestNvidia_DiscontinuityPixelFormat ./ffmpeg
```



