### PR TITLE
add functions for video comparison

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -1439,6 +1440,78 @@ func discontinuityPixelFormatSegment(t *testing.T, accel Acceleration) {
 func TestTranscoder_DiscontinuityPixelFormat(t *testing.T) {
 	discontinuityPixelFormatSegment(t, Software)
 }
+
+func compareVideo(t *testing.T, accel Acceleration) {
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+
+	cmd := `
+	cp "$1/../transcoder/test.ts" test.ts
+	`
+	run(cmd)
+
+	prof := P720p60fps16x9
+	for i := 1; i <= 3; i++ {
+		tc := NewTranscoder()
+		if i == 3 {
+			prof = P144p30fps16x9
+		}
+		in := &TranscodeOptionsIn{
+			Fname: fmt.Sprintf("%s/test.ts", dir),
+			Accel: accel,
+		}
+		out := []TranscodeOptions{{
+			Oname:   fmt.Sprintf("%s/out-%d.ts", dir, i),
+			Profile: prof,
+			Accel:   accel,
+		}}
+		_, err := tc.Transcode(in, out)
+		if err != nil {
+			t.Error(err)
+		}
+		tc.StopTranscoder()
+	}
+
+	res, err := CompareVideoByPath(dir+"/out-1.ts", dir+"/out-2.ts")
+	if err != nil || res != true {
+		t.Error(err)
+	}
+	res, err = CompareVideoByPath(dir+"/out-1.ts", dir+"/out-3.ts")
+	if err != nil || res != false {
+		t.Error(err)
+	}
+	res, err = CompareVideoByPath(dir+"/out-1.ts", dir+"/out-4.ts")
+	if err == nil || res != false {
+		t.Error(err)
+	}
+
+	//test ByBuffer function
+	data1, err := ioutil.ReadFile(dir + "/out-1.ts")
+	if err != nil {
+		t.Error(err)
+	}
+	data2, err := ioutil.ReadFile(dir + "/out-2.ts")
+	if err != nil {
+		t.Error(err)
+	}
+	data3, err := ioutil.ReadFile(dir + "/out-3.ts")
+	if err != nil {
+		t.Error(err)
+	}
+
+	res, err = CompareVideoByBuffer(data1, data2)
+	if err != nil || res != true {
+		t.Error(err)
+	}
+	res, err = CompareVideoByBuffer(data1, data3)
+	if err != nil || res != false {
+		t.Error(err)
+	}
+}
+func TestTranscoder_CompareVideo(t *testing.T) {
+	compareVideo(t, Software)
+}
+
 /*
 func detectionFreq(t *testing.T, accel Acceleration) {
 	run, dir := setupTest(t)

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -283,16 +283,16 @@ static int get_matchinfo(void *buffer, int len, struct match_info* info)
   ifmt_ctx->flags = AVFMT_FLAG_CUSTOM_IO;
   
   if ((ret = avformat_open_input(&ifmt_ctx, "", NULL, NULL)) < 0) {
-		LPMS_ERR(clean, "Cannot open input video file\n");
-	}
+		    LPMS_ERR(clean, "Cannot open input video file\n");
+  }
   
   if ((ret = avformat_find_stream_info(ifmt_ctx, NULL)) < 0) {
-    LPMS_ERR(clean, "Cannot find stream information\n");		
-	}
+        LPMS_ERR(clean, "Cannot find stream information\n");
+  }
   
   for (int i = 0; i < ifmt_ctx->nb_streams; i++) {
-		AVStream *stream;
-		stream = ifmt_ctx->streams[i];
+    AVStream *stream;
+    stream = ifmt_ctx->streams[i];
     AVCodecParameters *in_codecpar = stream->codecpar;
     if (in_codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
       info->width = in_codecpar->width;

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -10,7 +10,7 @@ struct match_info {
   int       height;
   uint64_t  bit_rate;
   int       packetcount; //video total packet count
-  uint64_t  timetamp;    //XOR sum of avpacket pts  
+  uint64_t  timestamp;    //XOR sum of avpacket pts  
   int       audiosum[4]; //XOR sum of audio data's md5(16 bytes)
 };
 
@@ -283,7 +283,7 @@ static int get_matchinfo(void *buffer, int len, struct match_info* info)
   ifmt_ctx->flags = AVFMT_FLAG_CUSTOM_IO;
   
   if ((ret = avformat_open_input(&ifmt_ctx, "", NULL, NULL)) < 0) {
-		    LPMS_ERR(clean, "Cannot open input video file\n");
+        LPMS_ERR(clean, "Cannot open input video file\n");
   }
   
   if ((ret = avformat_find_stream_info(ifmt_ctx, NULL)) < 0) {
@@ -315,7 +315,7 @@ static int get_matchinfo(void *buffer, int len, struct match_info* info)
       LPMS_ERR(clean, "Unable to read input");
     }
     info->packetcount++;
-    info->timetamp ^= packet->pts;
+    info->timestamp ^= packet->pts;
     if(packet->stream_index == audioid && packet->size > 0) {
       av_md5_sum((uint8_t*)md5tmp, packet->data, packet->size);
       for (int i=0; i<4; i++) info->audiosum[i] ^= md5tmp[i];
@@ -352,8 +352,8 @@ int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2
   if(ret < 0) return ret;
   //compare two matching information
   if (info1.width != info2.width || info1.height != info2.height || 
-      info1.bit_rate != info2.bit_rate  || info1.packetcount != info2.packetcount ||
-      info1.timetamp != info2.timetamp || memcmp(info1.audiosum ,info2.audiosum, 16)) {
+      info1.bit_rate != info2.bit_rate || info1.packetcount != info2.packetcount ||
+      info1.timestamp != info2.timestamp || memcmp(info1.audiosum, info2.audiosum, 16)) {
       ret = 1;
   }
 

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -1,7 +1,23 @@
-#include "extras.h"
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
+#include <libavutil/md5.h>
+#include "extras.h"
+#include "logging.h"
+
+struct match_info {
+  int       width;
+  int       height;
+  uint64_t  bit_rate;
+  int       packetcount; //video total packet count
+  uint64_t  timetamp;    //XOR sum of avpacket pts  
+  int       audiosum[4]; //XOR sum of audio data's md5(16 bytes)
+};
+
+struct buffer_data {
+    uint8_t *ptr;
+    size_t size; ///< size left in the buffer
+};
 
 //
 // Segmenter
@@ -163,5 +179,209 @@ int lpms_compare_sign_bypath(char *signpath1, char *signpath2)
 int lpms_compare_sign_bybuffer(void *buffer1, int len1, void *buffer2, int len2)
 {
   int ret = avfilter_compare_sign_bybuff(buffer1, len1, buffer2, len2);
+  return ret;
+}
+
+static int get_filesize(const char *filename)
+{
+    int fileLength = 0;
+    FILE *f = NULL;
+    f = fopen(filename, "rb");
+    if(f != NULL) {
+        fseek(f, 0, SEEK_END);
+        fileLength = ftell(f);
+        fclose(f);
+    }
+    return fileLength;
+}
+
+static uint8_t * get_filebuffer(const char *filename, int* fileLength)
+{
+    FILE *f = NULL;
+    unsigned int readLength, paddedLength = 0;
+    uint8_t *buffer = NULL;
+
+    //check input parameters
+    if (strlen(filename) <= 0) return buffer;
+    f = fopen(filename, "rb");
+    if (f == NULL) {
+        av_log(NULL, AV_LOG_ERROR, "Could not open the file %s\n", filename);
+        return buffer;
+    }
+    *fileLength = get_filesize(filename);
+    if(*fileLength > 0) {
+        // Cast to float is necessary to avoid int division
+        paddedLength = ceil(*fileLength / (float)AV_INPUT_BUFFER_PADDING_SIZE)*AV_INPUT_BUFFER_PADDING_SIZE + AV_INPUT_BUFFER_PADDING_SIZE;
+        buffer = (uint8_t*)av_calloc(paddedLength, sizeof(uint8_t));
+        if (!buffer) {
+            av_log(NULL, AV_LOG_ERROR, "Could not allocate memory for reading signature file\n");
+            fclose(f);
+            return NULL;
+        }
+        // Read entire file into memory
+        readLength = fread(buffer, sizeof(uint8_t), *fileLength, f);
+        if(readLength != *fileLength) {
+            av_log(NULL, AV_LOG_ERROR, "Could not read the file %s\n", filename);
+            free(buffer);
+            buffer = NULL;
+        }
+    }
+    fclose(f);
+    return buffer;
+}
+
+static int read_packet(void *opaque, uint8_t *buf, int buf_size)
+{
+    struct buffer_data *bd = (struct buffer_data *)opaque;
+    buf_size = FFMIN(buf_size, bd->size);
+
+    if (!buf_size)
+        return AVERROR_EOF;
+    /* copy internal buffer data to buf */
+    memcpy(buf, bd->ptr, buf_size);
+    bd->ptr  += buf_size;
+    bd->size -= buf_size;
+
+    return buf_size;
+}
+
+static int get_matchinfo(void *buffer, int len, struct match_info* info) 
+{
+  int ret = 0;
+  AVFormatContext* ifmt_ctx = NULL;
+  AVIOContext *avio_in = NULL;
+  AVPacket *packet = NULL;
+  int audioid = -1;
+  int md5tmp[4];
+  uint8_t *avio_ctx_buffer = NULL;
+  size_t  avio_ctx_buffer_size = 4096;
+  struct buffer_data bd = { 0 };
+  //initialize matching information
+  memset(info, 0x00, sizeof(struct match_info));
+
+   /* fill opaque structure used by the AVIOContext read callback */
+  bd.ptr  = buffer;
+  bd.size = len;
+
+  avio_ctx_buffer = av_malloc(avio_ctx_buffer_size);
+  if (!avio_ctx_buffer) {
+        ret = AVERROR(ENOMEM);
+        LPMS_ERR(clean, "Error allocating buffer");
+  }
+
+  avio_in = avio_alloc_context(avio_ctx_buffer, avio_ctx_buffer_size, 0, &bd, &read_packet, NULL, NULL);  
+  if (!avio_ctx_buffer) {
+        ret = AVERROR(ENOMEM);
+        LPMS_ERR(clean, "Error allocating context");
+  }
+  ifmt_ctx = avformat_alloc_context();
+  if (!ifmt_ctx) {
+        ret = AVERROR(ENOMEM);
+        LPMS_ERR(clean, "Error allocating avformat context");
+  }
+  ifmt_ctx->pb = avio_in;
+  ifmt_ctx->flags = AVFMT_FLAG_CUSTOM_IO;
+  
+  if ((ret = avformat_open_input(&ifmt_ctx, "", NULL, NULL)) < 0) {
+		LPMS_ERR(clean, "Cannot open input video file\n");
+	}
+  
+  if ((ret = avformat_find_stream_info(ifmt_ctx, NULL)) < 0) {
+    LPMS_ERR(clean, "Cannot find stream information\n");		
+	}
+  
+  for (int i = 0; i < ifmt_ctx->nb_streams; i++) {
+		AVStream *stream;
+		stream = ifmt_ctx->streams[i];
+    AVCodecParameters *in_codecpar = stream->codecpar;
+    if (in_codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      info->width = in_codecpar->width;
+      info->height = in_codecpar->height;
+      info->bit_rate = in_codecpar->bit_rate;
+    }
+    else if (in_codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      audioid = i;      
+    }
+  }
+  packet = av_packet_alloc();  
+  if (!packet) LPMS_ERR(clean, "Error allocating packet");
+  while (1) {
+    ret = av_read_frame(ifmt_ctx, packet);
+    if (ret == AVERROR_EOF) {
+      ret = 0;
+      break;
+    }
+    else if (ret < 0) {      
+      LPMS_ERR(clean, "Unable to read input");
+    }
+    info->packetcount++;
+    info->timetamp ^= packet->pts;
+    if(packet->stream_index == audioid && packet->size > 0) {
+      av_md5_sum((uint8_t*)md5tmp, packet->data, packet->size);
+      for (int i=0; i<4; i++) info->audiosum[i] ^= md5tmp[i];
+    }
+    av_packet_unref(packet);
+  }
+  
+clean:  
+  if(packet)
+    av_packet_free(&packet);
+  /* note: the internal buffer could have changed, and be != avio_ctx_buffer */
+  if(avio_in)
+    av_freep(&avio_in->buffer);
+  avio_context_free(&avio_in);
+  avformat_close_input(&ifmt_ctx);
+  return ret;
+}
+
+// compare two video buffers whether those matches or not.
+// @param buffer1         the pointer of the first video buffer.
+// @param buffer2         the pointer of the second video buffer.
+// @param len1            the length of the first video buffer.
+// @param len2            the length of the second video buffer.
+// @return  <0: error =0: matching 1: no matching
+int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2)
+{
+  int ret = 0; 
+  struct match_info info1, info2;
+
+  ret = get_matchinfo(buffer1,len1,&info1);
+  if(ret < 0) return ret;
+
+  ret = get_matchinfo(buffer2,len2,&info2);
+  if(ret < 0) return ret;
+  //compare two matching information
+  if (info1.width != info2.width || info1.height != info2.height || 
+      info1.bit_rate != info2.bit_rate  || info1.packetcount != info2.packetcount ||
+      info1.timetamp != info2.timetamp || memcmp(info1.audiosum ,info2.audiosum, 16)) {
+      ret = 1;
+  }
+
+  return ret;
+}
+
+// compare two video files whether those matches or not.
+// @param vpath1        full path of the first video file.
+// @param vpath2        full path of the second video file.
+// @return  <0: error =0: matching 1: no matching
+int lpms_compare_video_bypath(char *vpath1, char *vpath2)
+{
+  int ret = 0;
+  int len1, len2;
+  uint8_t *buffer1, *buffer2;
+  buffer1 = get_filebuffer(vpath1, &len1);
+  if(buffer1 == NULL) return AVERROR(ENOMEM);
+  buffer2 = get_filebuffer(vpath2, &len2);
+  if(buffer2 == NULL) {
+      av_freep(&buffer1);
+      return AVERROR(ENOMEM);
+  }
+  ret = lpms_compare_video_bybuffer(buffer1, len1, buffer2, len2);
+
+  if(buffer1 != NULL)
+      av_freep(&buffer1);
+  if(buffer2 != NULL)
+      av_freep(&buffer2);
+
   return ret;
 }

--- a/ffmpeg/extras.h
+++ b/ffmpeg/extras.h
@@ -5,5 +5,7 @@ int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char 
 int lpms_is_bypass_needed(char *fname);
 int lpms_compare_sign_bypath(char *signpath1, char *signpath2);
 int lpms_compare_sign_bybuffer(void *buffer1, int len1, void *buffer2, int len2);
+int lpms_compare_video_bypath(char *vpath1, char *vpath2);
+int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2);
 
 #endif // _LPMS_EXTRAS_H_

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -53,8 +53,8 @@ var FfEncoderLookup = map[Acceleration]map[VideoCodec]string{
 	Software: {
 		H264: "libx264",
 		H265: "libx265",
-		VP8:  "libvpx",
-		VP9:  "libvpx-vp9",
+		VP8: "libvpx",
+		VP9: "libvpx-vp9",
 	},
 	Nvidia: {
 		H264: "h264_nvenc",

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -719,6 +719,10 @@ func TestNvidia_DiscontinuityPixelFormat(t *testing.T) {
 	discontinuityPixelFormatSegment(t, Nvidia)
 }
 
+func TestNvidia_CompareVideo(t *testing.T) {
+	compareVideo(t, Nvidia)
+}
+
 /*
 func TestNvidia_DetectionFreq(t *testing.T) {
 	detectionFreq(t, Nvidia)


### PR DESCRIPTION
### Step 1: C level comparison function[#234](https://github.com/livepeer/internal-project-tracking/issues/234)
- **For two segments, read stream data directly from the memory buffer at same time.**[#292](https://github.com/livepeer/internal-project-tracking/issues/292)
  We have defined two following functions in C level which are callable from outsite. 
  `int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2)`[here](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R343)
  `int lpms_compare_video_bypath(char *vpath1, char *vpath2)`[here](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R367)

  In the second function, the file paths of two different video segments will be used as input values, while the buffers and the buffer sizes will be used in the first function.

  These functions will return one integer. Only when the return value is equal to 1, it means two videos are same. Otherwise(0 or less than 0), it means those two are not same.
  Inside the second function, I read the file and save the file content into buffer by using the following function. After that, the first function will be called.
  `static uint8_t * get_filebuffer(const char *filename, int* fileLength)`[here](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R198)

- **While reading buffer each segment, get metadata and count the number of Avpackets, compare time stamp.**[#293](https://github.com/livepeer/internal-project-tracking/issues/293)
  Two video will be compared with their width, height, bit_rate, packet count, XOR sum of avpacket PTS and XOR sum of hash(md5) of audio data.

  So we defined a struct [`match_info`](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R8) for video information and function [`get_matchinfo`](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R248) that we can fetch those information from the video content buffer.

  We get the metadata and necessary informations(packet-count, XOR of timestamp, XOR of md5 sum for audio data ) for a video comparison through [`get_matchinfo`](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R248) function. 

  The following is a simple code snippet.
```
    info->packetcount++;
    info->timetamp ^= packet->pts;
    if(packet->stream_index == audioid && packet->size > 0) {
      av_md5_sum((uint8_t*)md5tmp, packet->data, packet->size);
      for (int i=0; i<4; i++) info->audiosum[i] ^= md5tmp[i];
    }
```
- **Meanwhile, run comparison of audio buffers with memcmp function.**[#293](https://github.com/livepeer/internal-project-tracking/issues/293)
  By using the [`get_matchinfo`](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R248) function, we can get two struct variables for metadata of two videos.
  We compare video information in [here](https://github.com/livepeer/lpms/pull/292/files#diff-998114575433dc60658ff6542df0970e08cef7970396134aeedf868b90aace10R354).

### Step 2: Go level comparison function[#235](https://github.com/livepeer/internal-project-tracking/issues/235)
- **Write GO wrap API for lpms C level function.**
  We have defined two following functions in G level for lpms C level functions.
  `func CompareVideoByPath(fname1 string, fname2 string) (bool, error)`[here](https://github.com/livepeer/lpms/pull/292/files#diff-4ab68a4de67768f1acb5be217d4ec78bab27b99381025beedf82c11a5fa9c7aeR178)
  `func CompareVideoByBuffer(data1 []byte, data2 []byte) (bool, error)`[here](https://github.com/livepeer/lpms/pull/292/files#diff-4ab68a4de67768f1acb5be217d4ec78bab27b99381025beedf82c11a5fa9c7aeR199)

- **Unit test and benchmarking**
  By using [this](https://github.com/livepeer/lpms/pull/292/files#diff-13c64c7b8c1fc08e8f08edcf4e1b46d95ddbd51b93134f2cf896497569d62e60R1511) unit test, we can simply check whether the video comparison is working correctly or not.
  This test will output 3 files: out-1.ts, out-2.ts, out-3.ts.
  out-1.ts is same with out-2.ts, but different from out-3.ts.
  When we input out-1.ts and out-2.ts, it will return `true`.
  When we input out-1.ts and out-3.ts, it will return `false`.
  When we input out-1.ts and out-4.ts, it will return `false` and error `Can not open file out-4.ts`.