### PR TITLE
Unit test for signature_cuda filter

### DIFF
--- a/ffmpeg/sign_cuda_test.go
+++ b/ffmpeg/sign_cuda_test.go
@@ -1,0 +1,67 @@
+//go:build nvidia
+// +build nvidia
+
+package ffmpeg
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCuda_SignDataCreate(t *testing.T) {
+	_, dir := setupTest(t)
+
+	filesMustExist := func(names []string) {
+		for _, name := range names {
+			_, err := os.Stat(dir + name)
+			if os.IsNotExist(err) {
+				t.Error(err)
+			}
+		}
+	}
+	compareSignatures := func(firstName, secondName string) {
+		res, err := CompareSignatureByPath(dir+firstName, dir+secondName)
+		if err != nil || res != true {
+			t.Error(err)
+		}
+	}
+
+	defer os.RemoveAll(dir)
+
+	in := &TranscodeOptionsIn{Fname: "../transcoder/test.ts"}
+	out := []TranscodeOptions{{
+		Oname:        dir + "/cpu_signtest1.ts",
+		Profile:      P720p60fps16x9,
+		AudioEncoder: ComponentOptions{Name: "copy"},
+		CalcSign:     true,
+	}, {
+		Oname:        dir + "/cpu_signtest2.ts",
+		Profile:      P360p30fps16x9,
+		AudioEncoder: ComponentOptions{Name: "copy"},
+		CalcSign:     true,
+	}, {
+		Oname:        dir + "/cuda_signtest1.ts",
+		Profile:      P720p60fps16x9,
+		AudioEncoder: ComponentOptions{Name: "copy"},
+		CalcSign:     true,
+		Accel:        Nvidia,
+	}, {
+		Oname:        dir + "/cuda_signtest2.ts",
+		Profile:      P360p30fps16x9,
+		AudioEncoder: ComponentOptions{Name: "copy"},
+		CalcSign:     true,
+		Accel:        Nvidia,
+	}}
+	_, err := Transcode3(in, out)
+	if err != nil {
+		t.Error(err)
+	}
+	filesMustExist([]string{
+		"/cpu_signtest1.ts.bin",
+		"/cpu_signtest2.ts.bin",
+		"/cuda_signtest1.ts.bin",
+		"/cuda_signtest2.ts.bin",
+	})
+	compareSignatures("/cpu_signtest1.ts.bin", "/cuda_signtest1.ts.bin")
+	compareSignatures("/cpu_signtest2.ts.bin", "/cuda_signtest2.ts.bin")
+}

--- a/ffmpeg/sign_nvidia_test.go
+++ b/ffmpeg/sign_nvidia_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCuda_SignDataCreate(t *testing.T) {
+func TestNvidia_SignDataCreate(t *testing.T) {
 	_, dir := setupTest(t)
 
 	filesMustExist := func(names []string) {
@@ -40,13 +40,13 @@ func TestCuda_SignDataCreate(t *testing.T) {
 		AudioEncoder: ComponentOptions{Name: "copy"},
 		CalcSign:     true,
 	}, {
-		Oname:        dir + "/cuda_signtest1.ts",
+		Oname:        dir + "/nvidia_signtest1.ts",
 		Profile:      P720p60fps16x9,
 		AudioEncoder: ComponentOptions{Name: "copy"},
 		CalcSign:     true,
 		Accel:        Nvidia,
 	}, {
-		Oname:        dir + "/cuda_signtest2.ts",
+		Oname:        dir + "/nvidia_signtest2.ts",
 		Profile:      P360p30fps16x9,
 		AudioEncoder: ComponentOptions{Name: "copy"},
 		CalcSign:     true,
@@ -59,9 +59,9 @@ func TestCuda_SignDataCreate(t *testing.T) {
 	filesMustExist([]string{
 		"/cpu_signtest1.ts.bin",
 		"/cpu_signtest2.ts.bin",
-		"/cuda_signtest1.ts.bin",
-		"/cuda_signtest2.ts.bin",
+		"/nvidia_signtest1.ts.bin",
+		"/nvidia_signtest2.ts.bin",
 	})
-	compareSignatures("/cpu_signtest1.ts.bin", "/cuda_signtest1.ts.bin")
-	compareSignatures("/cpu_signtest2.ts.bin", "/cuda_signtest2.ts.bin")
+	compareSignatures("/cpu_signtest1.ts.bin", "/nvidia_signtest1.ts.bin")
+	compareSignatures("/cpu_signtest2.ts.bin", "/nvidia_signtest2.ts.bin")
 }


### PR DESCRIPTION
# Why

#294 Create missing unit test for `signature_cuda` filter.

# Description

Sample video file `test.ts` is transcoded to 720p and 360p profiles both using software encoder and nvidia encoder, 4 output files in total.

We make sure output files are created.

`CompareSignatureByPath()` function is used to compare cuda output to cpu output, meaning that the signatures fuzzy match.

# How to test

- `cd lpms/ffmpeg`
- `go test -v --tags=nvidia -run TestNvidia_SignDataCreate`
- expect in output:
```
=== RUN   TestNvidia_SignDataCreate
--- PASS: TestNvidia_SignDataCreate(7.25s)
PASS
ok      github.com/livepeer/lpms/ffmpeg 7.487s
```
- Check `nvtop` to see hardware encoding was used:

![gpu-usage-diagram](https://user-images.githubusercontent.com/3812017/151016000-49159da4-d464-4c5e-b9fb-5e3370aa6814.png)

# Describe the feeling

![Devs feeling](https://user-images.githubusercontent.com/3812017/151018174-9416a7c6-3bb4-4b6f-a86a-feea6eb44682.gif)

