### PR TITLE
ffmpeg: Move here the ParseProfiles(), DefaultProfileName() and Encod…

### DIFF
--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -1,11 +1,11 @@
 package ffmpeg
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
-	"encoding/json"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/m3u8"
@@ -258,4 +258,3 @@ func ParseProfiles(injson []byte) ([]VideoProfile, error) {
 	}
 	return parsedProfiles, nil
 }
-

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -218,7 +218,6 @@ func ParseProfiles(injson []byte) ([]VideoProfile, error) {
 	decodedJson := &profilesJson{}
 	err := json.Unmarshal(injson, &decodedJson.Profiles)
 	if err != nil {
-		// TODO: include err info into returned error
 		return parsedProfiles, fmt.Errorf("Unable to unmarshal the passed transcoding option: %w", err)
 	}
 	for _, profile := range decodedJson.Profiles {

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -1,13 +1,17 @@
 package ffmpeg
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
+	"encoding/json"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/m3u8"
 )
+
+var ErrProfName = fmt.Errorf("unknown VideoProfile profile name")
 
 type Format int
 
@@ -26,6 +30,15 @@ const (
 	ProfileH264High
 	ProfileH264ConstrainedHigh
 )
+
+var EncoderProfileLookup = map[string]Profile{
+	"":                    ProfileNone,
+	"none":                ProfileNone,
+	"h264baseline":        ProfileH264Baseline,
+	"h264main":            ProfileH264Main,
+	"h264high":            ProfileH264High,
+	"h264constrainedhigh": ProfileH264ConstrainedHigh,
+}
 
 // For additional "special" GOP values
 // enumerate backwards from here
@@ -175,3 +188,74 @@ func (a ByName) Less(i, j int) bool {
 // 	res, _ := strconv.Atoi(intstr)
 // 	return res
 // }
+
+func EncoderProfileNameToValue(profile string) (Profile, error) {
+	p, ok := EncoderProfileLookup[strings.ToLower(profile)]
+	if !ok {
+		return -1, ErrProfName
+	}
+	return p, nil
+}
+
+func DefaultProfileName(width int, height int, bitrate int) string {
+	return fmt.Sprintf("%dx%d_%d", width, height, bitrate)
+}
+
+func ParseProfiles(injson []byte) ([]VideoProfile, error) {
+	type profilesJson struct {
+		Profiles []struct {
+			Name    string `json:"name"`
+			Width   int    `json:"width"`
+			Height  int    `json:"height"`
+			Bitrate int    `json:"bitrate"`
+			FPS     uint   `json:"fps"`
+			FPSDen  uint   `json:"fpsDen"`
+			Profile string `json:"profile"`
+			GOP     string `json:"gop"`
+		} `json:"profiles"`
+	}
+	parsedProfiles := []VideoProfile{}
+	decodedJson := &profilesJson{}
+	err := json.Unmarshal(injson, &decodedJson.Profiles)
+	if err != nil {
+		// TODO: include err info into returned error
+		return parsedProfiles, fmt.Errorf("Unable to unmarshal the passed transcoding option: %w", err)
+	}
+	for _, profile := range decodedJson.Profiles {
+		name := profile.Name
+		if name == "" {
+			name = "custom_" + DefaultProfileName(profile.Width, profile.Height, profile.Bitrate)
+		}
+		var gop time.Duration
+		if profile.GOP != "" {
+			if profile.GOP == "intra" {
+				gop = GOPIntraOnly
+			} else {
+				gopFloat, err := strconv.ParseFloat(profile.GOP, 64)
+				if err != nil {
+					return parsedProfiles, fmt.Errorf("Cannot parse the GOP value in the transcoding options: %w", err)
+				}
+				if gopFloat <= 0.0 {
+					return parsedProfiles, fmt.Errorf("Invalid gop value %f. Please set it to a positive value", gopFloat)
+				}
+				gop = time.Duration(gopFloat * float64(time.Second))
+			}
+		}
+		encodingProfile, err := EncoderProfileNameToValue(profile.Profile)
+		if err != nil {
+			return parsedProfiles, fmt.Errorf("Unable to parse the H264 encoder profile: %w", err)
+		}
+		prof := VideoProfile{
+			Name:         name,
+			Bitrate:      fmt.Sprint(profile.Bitrate),
+			Framerate:    profile.FPS,
+			FramerateDen: profile.FPSDen,
+			Resolution:   fmt.Sprintf("%dx%d", profile.Width, profile.Height),
+			Profile:      encodingProfile,
+			GOP:          gop,
+		}
+		parsedProfiles = append(parsedProfiles, prof)
+	}
+	return parsedProfiles, nil
+}
+

--- a/transcoder/ffmpeg_segment_failcase_test.go
+++ b/transcoder/ffmpeg_segment_failcase_test.go
@@ -1,3 +1,4 @@
+//go:build nvidia
 // +build nvidia
 
 package transcoder


### PR DESCRIPTION
# Why

Avoiding code duplication. Moving common functions to ffmpeg/videoprofile.go

A follow up to #276.

# Description

Changing code organization, no change in logic should be noticable.

# How to test

Add test suite according to #276.

- `cd lpms/transcoder`
- `FAILCASE_PATH="/somewhere/livepeer-production-failed-transcodes/" go test --tags=nvidia -timeout 30m -run Nvidia`
- Tests should fail normally
- When json parsing error happens output should look like:
```
Failed in parsing input: 1 [] /tmp/TestNvidia_CheckFailCase3227199022/sometestcasename.ts
```
- Parsing error should not stop testing remaining inputs

