### PR TITLE
Fix the failure of TestTranscoder_DetectionFreq in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             rm install_ffmpeg.sh || true
             wget https://raw.githubusercontent.com/livepeer/go-livepeer/master/install_ffmpeg.sh
 
-      # - restore_cache:
-      #     key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
+      - restore_cache:
+          key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
 
       - run:
           name: "Tweak PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
           GOROOT: /usr/local/go
           PKG_CONFIG_PATH: "/home/circleci/compiled/lib/pkgconfig"
           # compile ffmpeg with tools required for tests
-          BUILD_TAGS: "debug-video"
+          BUILD_TAGS: "debug-video experimental"
           # required for libx265 support (software) for running tests on CI
-          LD_LIBRARY_PATH: "/home/circleci/compiled/lib"
+          LD_LIBRARY_PATH: "/home/circleci/compiled/lib:/usr/local/lib"
     steps:
       - checkout
 
@@ -49,8 +49,7 @@ jobs:
       - run:
           name: "Download tasmodel.pb"
           command: |
-            wget https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb
-            mv tasmodel.pb ./ffmpeg
+            wget https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb -P ffmpeg
       
       - run:
           name: "Build LPMS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             rm install_ffmpeg.sh || true
             wget https://raw.githubusercontent.com/livepeer/go-livepeer/master/install_ffmpeg.sh
 
-      - restore_cache:
-          key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
+      # - restore_cache:
+      #     key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
 
       - run:
           name: "Tweak PATH"
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: "Download tasmodel.pb"
           command: |
-            wget https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb -P ffmpeg
+            wget https://github.com/livepeer/livepeer-ml/releases/latest/download/tasmodel.pb -P ffmpeg
       
       - run:
           name: "Build LPMS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,13 @@ jobs:
             - "/home/circleci/ffmpeg"
             - "/home/circleci/compiled"
           key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
-
+          
+      - run:
+          name: "Download tasmodel.pb"
+          command: |
+            wget https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb
+            mv tasmodel.pb ./ffmpeg
+      
       - run:
           name: "Build LPMS"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             wget https://raw.githubusercontent.com/livepeer/go-livepeer/master/install_ffmpeg.sh
 
       - restore_cache:
-          key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
+          key: ffmpeg-cache-v1-{{ checksum "install_ffmpeg.sh" }}
 
       - run:
           name: "Tweak PATH"
@@ -44,7 +44,7 @@ jobs:
             - "/home/circleci/libvpx"
             - "/home/circleci/ffmpeg"
             - "/home/circleci/compiled"
-          key: ffmpeg-cache-{{ checksum "install_ffmpeg.sh" }}
+          key: ffmpeg-cache-v1-{{ checksum "install_ffmpeg.sh" }}
           
       - run:
           name: "Download tasmodel.pb"


### PR DESCRIPTION
This is related with #301 
- Before we run `TestTranscoder_DetectionFreq` function, we need to download `tasmodel.pb` first.
- We need to set the library path for the Tensorflow linking in env variables.
- To build the ffmpeg with libtensorflow, `experimental` should be contained in BUILD_TAGS.