### PR TITLE
segmenter: Remove invalid netcat flag in test

### DIFF
--- a/segmenter/video_segmenter_test.go
+++ b/segmenter/video_segmenter_test.go
@@ -445,7 +445,7 @@ func TestServerDisconnect(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	cmd := "dd if=/dev/urandom count=1 ibs=2000 | nc -Nl " + port
+	cmd := "dd if=/dev/urandom count=1 ibs=2000 | nc -l " + port
 	go exec.CommandContext(ctx, "bash", "-c", cmd).Output()
 
 	err := RunRTMPToHLS(vs, ctx)


### PR DESCRIPTION
This was causing tests to fail when I ran locally (M1 Mac) due to the flag being used wrongly for that version of Netcat:

https://github.com/st3fan/osx-10.9/blob/master/netcat-20/netcat.c#L271-L276

It also seems to not be a valid flag for some Linux versions:  https://linux.die.net/man/1/nc