### PR TITLE
Add error message for K8s container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             wget https://raw.githubusercontent.com/livepeer/go-livepeer/master/install_ffmpeg.sh
 
       - restore_cache:
-          key: ffmpeg-cache-v1-{{ checksum "install_ffmpeg.sh" }}
+          key: ffmpeg-cache-v2-{{ checksum "install_ffmpeg.sh" }}
 
       - run:
           name: "Tweak PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             wget https://raw.githubusercontent.com/livepeer/go-livepeer/master/install_ffmpeg.sh
 
       - restore_cache:
-          key: ffmpeg-cache-v2-{{ checksum "install_ffmpeg.sh" }}
+          key: ffmpeg-cache-v1-{{ checksum "install_ffmpeg.sh" }}
 
       - run:
           name: "Tweak PATH"


### PR DESCRIPTION
Related to [git Action CI](https://github.com/livepeer/livepeer-infra/issues/803)

When have a test on the host, we get "Connection refused" error message but get "Cannot assign requested address" error message in a container on K8s.
I try to find a solution with helm chart on K8s, but can't find a reasonable way to fix this. so decided to add another error message to the Unit test code.
Thank @cyberj0g  for fixing CI/CD error on ubuntu.


