### PR TITLE
Handle constrained high H.264 profile for Netint

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -633,8 +633,12 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 			}
 			switch p.Profile.Profile {
 			case ProfileH264Baseline, ProfileH264ConstrainedHigh:
-				p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]
-				p.VideoEncoder.Opts["bf"] = "0"
+				if p.Accel != Netint {
+					p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]
+					p.VideoEncoder.Opts["bf"] = "0"
+				} else {
+					xcoderOutParamsStr = "profile=high"
+				}
 			case ProfileH264Main, ProfileH264High:
 				if p.Accel != Netint {
 					p.VideoEncoder.Opts["profile"] = ProfileParameters[p.Profile.Profile]


### PR DESCRIPTION
Handle Constrained High profile for Netint. The difference between constrained high and high is absence of B-frames. It needs clarification whether B-frames are configurable for Netint H.264 encoder.