### PR TITLE
remove metadata comparison in the video comparison

### DIFF
--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -376,9 +376,7 @@ int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2
   ret = get_matchinfo(buffer2,len2,&info2);
   if(ret < 0) return ret;
   //compare two matching information
-  if (info1.width != info2.width || info1.height != info2.height ||
-      info1.bit_rate != info2.bit_rate || info1.packetcount != info2.packetcount ||
-      info1.timestamp != info2.timestamp || memcmp(info1.audiosum, info2.audiosum, 16)) {
+  if (info1.width != info2.width || info1.height != info2.height || memcmp(info1.audiosum, info2.audiosum, 16)) {
       ret = 1;
   }
 


### PR DESCRIPTION
For #[352](https://github.com/livepeer/internal-project-tracking/issues/352)
Regarding [this ](https://github.com/livepeer/lpms/pull/279#discussion_r778763259)changes, there are differences in GPU/CPU in bitrate, timestamp, and packet count. so, it removed the comparison of these.