### PR TITLE
reopen context when it added audio track into the segment

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -883,7 +883,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		} else {
 			//check if we need to reopen demuxer because added audio in video
 			if format.Acodec != "" && !isAudioAllDrop(ps) {
-				if (t.lastacodec == "") || (len(t.lastacodec) > 0 && t.lastacodec != format.Acodec) {
+				if (t.lastacodec == "") || (t.lastacodec != "" && t.lastacodec != format.Acodec) {
 					reopendemux = 1
 					t.lastacodec = format.Acodec
 				}

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -85,10 +85,11 @@ type ComponentOptions struct {
 }
 
 type Transcoder struct {
-	handle  *C.struct_transcode_thread
-	stopped bool
-	started bool
-	mu      *sync.Mutex
+	handle     *C.struct_transcode_thread
+	stopped    bool
+	started    bool
+	lastacodec string
+	mu         *sync.Mutex
 }
 
 type TranscodeOptionsIn struct {
@@ -593,6 +594,15 @@ func ensureEncoderLimits(outputs []TranscodeOptions, format MediaFormatInfo) err
 	return nil
 }
 
+func isAudioAllDrop(ps []TranscodeOptions) bool {
+	for _, p := range ps {
+		if p.AudioEncoder.Name != "drop" {
+			return false
+		}
+	}
+	return true
+}
+
 // create C output params array and return it along with corresponding finalizer
 // function that makes sure there are no C memory leaks
 func createCOutputParams(input *TranscodeOptionsIn, ps []TranscodeOptions) ([]C.output_params, func(), error) {
@@ -842,6 +852,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	if input == nil {
 		return nil, ErrTranscoderInp
 	}
+	var reopendemux C.int
+	reopendemux = 0
 	// don't read metadata for pipe input, because it can't seek back and av_find_input_format in the decoder will fail
 	if !strings.HasPrefix(strings.ToLower(input.Fname), "pipe:") {
 		status, format, err := GetCodecInfo(input.Fname)
@@ -864,8 +876,18 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 				// Audio-only segment, fail fast right here as we cannot handle them nicely
 				return nil, ErrTranscoderVid
 			}
+			// keep last audio codec
+			t.lastacodec = format.Acodec
 			// Stream is either OK or completely broken, let the transcoder handle it
 			t.started = true
+		} else {
+			//check if we need to reopen demuxer because added audio in video
+			if format.Acodec != "" && !isAudioAllDrop(ps) {
+				if (t.lastacodec == "") || (len(t.lastacodec) > 0 && t.lastacodec != format.Acodec) {
+					reopendemux = 1
+					t.lastacodec = format.Acodec
+				}
+			}
 		}
 	}
 	hw_type, err := accelDeviceType(input.Accel)
@@ -907,7 +929,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	xcoderParams := C.CString("")
 	defer C.free(unsafe.Pointer(xcoderParams))
 	inp := &C.input_params{fname: fname, hw_type: hw_type, device: device, xcoderParams: xcoderParams,
-		handle: t.handle}
+		handle: t.handle, reopendemux: reopendemux}
 	if input.Transmuxing {
 		inp.transmuxe = 1
 	}

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -789,3 +789,7 @@ func TestTranscoder_Portrait(t *testing.T) {
 }
 
 // XXX test bframes or delayed frames
+
+func TestNvidia_DiscontinuityAudioSegment(t *testing.T) {
+	discontinuityAudioSegment(t, Nvidia)
+}

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -439,6 +439,12 @@ int lpms_transcode(input_params *inp, output_params *params,
     if (ret < 0) {
       return ret;
     }
+  } else if (inp->reopendemux) {
+      free_input(&h->ictx);
+      ret = open_input(inp, &h->ictx);
+      if (ret < 0) {
+        return ret;
+      }
   }
 
   if (h->nb_outputs != nb_outputs) {

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -56,6 +56,7 @@ typedef struct {
   component_opts video;
 
   int transmuxe;
+  int reopendemux;
 } input_params;
 
 #define MAX_CLASSIFY_SIZE 10


### PR DESCRIPTION
For fixing #337 

- added lastacodec variable in Transcoder structure
- call ["open_input"](https://github.com/livepeer/lpms/blob/622b50738904a1c7d75a3b9650f1cf1341980670/ffmpeg/decoder.c#L298) to recognize the audio track
- added unit test [here](https://github.com/livepeer/lpms/blob/e7ca14c09ef1e1302963b844376acd0dd8b1bc00/ffmpeg/api_test.go#L1575)