### PR TITLE
Demux reopen not in lpms_transcode()

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -852,8 +852,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	if input == nil {
 		return nil, ErrTranscoderInp
 	}
-	var reopendemux C.int
-	reopendemux = 0
+	var reopendemux bool
+	reopendemux = false
 	// don't read metadata for pipe input, because it can't seek back and av_find_input_format in the decoder will fail
 	if !strings.HasPrefix(strings.ToLower(input.Fname), "pipe:") {
 		status, format, err := GetCodecInfo(input.Fname)
@@ -881,10 +881,16 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 			// Stream is either OK or completely broken, let the transcoder handle it
 			t.started = true
 		} else {
-			//check if we need to reopen demuxer because added audio in video
+			// check if we need to reopen demuxer because added audio in video
+			// TODO: fixes like that are needed because handling of cfg change in
+			// LPMS is a joke. We need to decide whether LPMS should support full
+			// dynamic config one day and either implement it there, or implement
+			// some generic workaround for the problem in Go code, such as marking
+			// config changes as significant/insignificant and re-creating the instance
+			// if the former type change happens
 			if format.Acodec != "" && !isAudioAllDrop(ps) {
 				if (t.lastacodec == "") || (t.lastacodec != "" && t.lastacodec != format.Acodec) {
-					reopendemux = 1
+					reopendemux = true
 					t.lastacodec = format.Acodec
 				}
 			}
@@ -929,7 +935,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	xcoderParams := C.CString("")
 	defer C.free(unsafe.Pointer(xcoderParams))
 	inp := &C.input_params{fname: fname, hw_type: hw_type, device: device, xcoderParams: xcoderParams,
-		handle: t.handle, reopendemux: reopendemux}
+		handle: t.handle}
 	if input.Transmuxing {
 		inp.transmuxe = 1
 	}
@@ -942,6 +948,16 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	if len(params) > 0 {
 		paramsPointer = (*C.output_params)(&params[0])
 		resultsPointer = (*C.output_results)(&results[0])
+	}
+	if reopendemux {
+		// forcefully close and open demuxer
+		ret := int(C.lpms_transcode_reopen_demux(inp))
+		if ret != 0 {
+			if LogTranscodeErrors {
+				glog.Error("Reopen demux returned : ", ErrorMap[ret])
+			}
+			return nil, ErrorMap[ret]
+		}
 	}
 	ret := int(C.lpms_transcode(inp, paramsPointer, resultsPointer, C.int(len(params)), decoded))
 	if ret != 0 {

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -439,12 +439,6 @@ int lpms_transcode(input_params *inp, output_params *params,
     if (ret < 0) {
       return ret;
     }
-  } else if (inp->reopendemux) {
-      free_input(&h->ictx);
-      ret = open_input(inp, &h->ictx);
-      if (ret < 0) {
-        return ret;
-      }
   }
 
   if (h->nb_outputs != nb_outputs) {
@@ -469,6 +463,11 @@ int lpms_transcode(input_params *inp, output_params *params,
   h->initialized = 1;
 
   return ret;
+}
+
+int lpms_transcode_reopen_demux(input_params *inp) {
+  free_input(&inp->handle->ictx);
+  return open_input(inp, &inp->handle->ictx);
 }
 
 struct transcode_thread* lpms_transcode_new() {

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -56,7 +56,6 @@ typedef struct {
   component_opts video;
 
   int transmuxe;
-  int reopendemux;
 } input_params;
 
 #define MAX_CLASSIFY_SIZE 10
@@ -92,6 +91,7 @@ enum LPMSLogLevel {
 
 void lpms_init(enum LPMSLogLevel max_level);
 int  lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
+int lpms_transcode_reopen_demux(input_params *inp);
 struct transcode_thread* lpms_transcode_new();
 struct transcode_thread* lpms_transcode_new_with_dnn(lvpdnn_opts *dnn_opts);
 void lpms_transcode_stop(struct transcode_thread* handle);


### PR DESCRIPTION
Due to my omission the previous solution was going against the
grain of upcoming refactoring changes in lpms_transcode().
Basically the idea is to have streamlined transcoder init() code
so that changes such as Low Latency can be implemented easily in
one place, instead of being distributed in many flows.

Besides, adding yet another "mode" to lpms_transcode() is not
really needed. The transcoder is kinda like any other object
instance - it retains its status between the lpms_transcode()
calls. So I think it is easier to add extra operations (such
as lpms_transcode_close_demux() introduced here) to change said
state, instead of increase the complexity of lpms_transcode()
call.

And finally, perhaps most important thing:
Changes like these are needed because LPMS doesn't really chave
good handling of changing configuration (in this case we are
talking about changing from container stream without audio to
the one with audio). It kind of pretends of doing so, and will
handle certain small differences kinda ok, but it is very easy
to come up with situation that will break it completely.

Ideally, I'd like to change that by reducing transient state
to the minimum (such as certain number of hardware buffers for
decoding and encoding) and really re-initialize everything else
that can be reinitialized cheaply. This however requires low
level hardware codec programming, it is not possible to do that
from ffmpeg level.