### PR TITLE
add exception proc for weird DTS and PTS

### DIFF
--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -419,6 +419,7 @@ int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost)
       //so we make DTS and PTS of these packets accept in muxer.
       /*https://github.com/livepeer/FFmpeg/blob/dd7e5c34e75fcb8ed79e0798d190d523e11ce60b/libavformat/mux.c#L604*/
       if (pkt->dts != AV_NOPTS_VALUE && pkt->pts != AV_NOPTS_VALUE && pkt->dts > pkt->pts) {
+          //picking middle value from (pkt->pts, pkt->dts and oct->last_video_dts + 1). 
           pkt->pts = pkt->dts = pkt->pts + pkt->dts + octx->last_video_dts + 1
                      - FFMIN3(pkt->pts, pkt->dts, octx->last_video_dts + 1)
                      - FFMAX3(pkt->pts, pkt->dts, octx->last_video_dts + 1);

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -45,6 +45,8 @@ static int add_video_stream(struct output_ctx *octx, struct input_ctx *ictx)
     }
     if (ret < 0) LPMS_ERR(add_video_err, "Error setting video params from encoder");
   } else LPMS_ERR(add_video_err, "No video encoder, not a copy; what is this?");
+
+  octx->last_video_dts = AV_NOPTS_VALUE;
   return 0;
 
 add_video_err:
@@ -410,6 +412,26 @@ int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost)
         }
       }
       octx->last_audio_dts = pkt->dts;
+  }
+  if (AVMEDIA_TYPE_VIDEO == ost->codecpar->codec_type) {
+      //after a long time of transcoding on GPU, exactly 6.5 hours, sometimes here,
+      //got weird packets which DTS > PTS. But muxer doesn't agree with those packets.
+      //so we make DTS and PTS of these packets accept in muxer.
+      /*https://github.com/livepeer/FFmpeg/blob/dd7e5c34e75fcb8ed79e0798d190d523e11ce60b/libavformat/mux.c#L604*/
+      if (pkt->dts != AV_NOPTS_VALUE && pkt->pts != AV_NOPTS_VALUE && pkt->dts > pkt->pts) {
+          pkt->pts = pkt->dts = pkt->pts + pkt->dts + octx->last_video_dts + 1
+                     - FFMIN3(pkt->pts, pkt->dts, octx->last_video_dts + 1)
+                     - FFMAX3(pkt->pts, pkt->dts, octx->last_video_dts + 1);
+          if (pkt->dts != AV_NOPTS_VALUE && octx->last_video_dts != AV_NOPTS_VALUE) {
+              int64_t max = octx->last_video_dts + !(octx->oc->oformat->flags & AVFMT_TS_NONSTRICT);
+              // check if dts is bigger than previous last dts or not, not then that's non-monotonic
+              if (pkt->dts < max) {
+                  if (pkt->pts >= pkt->dts) pkt->pts = FFMAX(pkt->pts, max);
+                  pkt->dts = max;
+              }
+          }
+      }
+      octx->last_video_dts = pkt->dts;
   }
 
   return av_interleaved_write_frame(octx->oc, pkt);

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -422,13 +422,11 @@ int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost)
           pkt->pts = pkt->dts = pkt->pts + pkt->dts + octx->last_video_dts + 1
                      - FFMIN3(pkt->pts, pkt->dts, octx->last_video_dts + 1)
                      - FFMAX3(pkt->pts, pkt->dts, octx->last_video_dts + 1);
-          if (pkt->dts != AV_NOPTS_VALUE && octx->last_video_dts != AV_NOPTS_VALUE) {
-              int64_t max = octx->last_video_dts + !(octx->oc->oformat->flags & AVFMT_TS_NONSTRICT);
-              // check if dts is bigger than previous last dts or not, not then that's non-monotonic
-              if (pkt->dts < max) {
-                  if (pkt->pts >= pkt->dts) pkt->pts = FFMAX(pkt->pts, max);
-                  pkt->dts = max;
-              }
+          int64_t max = octx->last_video_dts + !(octx->oc->oformat->flags & AVFMT_TS_NONSTRICT);
+          // check if dts is bigger than previous last dts or not, not then that's non-monotonic
+          if (pkt->dts < max) {
+              if (pkt->pts >= pkt->dts) pkt->pts = FFMAX(pkt->pts, max);
+              pkt->dts = max;
           }
       }
       octx->last_video_dts = pkt->dts;

--- a/ffmpeg/filter.h
+++ b/ffmpeg/filter.h
@@ -61,6 +61,8 @@ struct output_ctx {
 
   int64_t last_audio_dts;     //dts of the last audio packet sent to the muxer
 
+  int64_t last_video_dts;     //dts of the last video packet sent to the muxer
+
   int64_t gop_time, gop_pts_len, next_kf_pts; // for gop reset
 
   int64_t clip_from, clip_to, clip_from_pts, clip_to_pts, clip_started, clip_start_pts, clip_start_pts_found; // for clipping


### PR DESCRIPTION
For [#379](https://github.com/livepeer/internal-project-tracking/issues/397)
After a long time of transcoding on GPU, exactly 6.5 hours, sometimes [here](https://github.com/livepeer/lpms/blob/8bb5759971e725e04a5636e790737dd7adb930a6/ffmpeg/encoder.c#L382), got weird packets which[ DTS > PTS](https://github.com/livepeer/FFmpeg/blob/dd7e5c34e75fcb8ed79e0798d190d523e11ce60b/libavformat/mux.c#L604). But muxer doesn't agree with those packets. so we make DTS and PTS of these packets accept in muxer.
