### PR TITLE
Second part of refactoring changes

### DIFF
--- a/ffmpeg/api_test.go
+++ b/ffmpeg/api_test.go
@@ -88,7 +88,7 @@ func TestAPI_SkippedSegment(t *testing.T) {
 }
 
 func TestTranscoderAPI_InvalidFile(t *testing.T) {
-	// Test the following file open results on input: fail, success, fail, success
+	// Test the following file open results on input: success, fail, success
 
 	tc := NewTranscoder()
 	defer tc.StopTranscoder()
@@ -100,18 +100,9 @@ func TestTranscoderAPI_InvalidFile(t *testing.T) {
 		Muxer:        ComponentOptions{Name: "null"},
 	}}
 
-	// fail # 1
-	in.Fname = "none"
-	_, err := tc.Transcode(in, out)
-	if err == nil || err.Error() != "TranscoderInvalidVideo" {
-		// Early codec check didn't find video in missing input file so we get `TranscoderInvalidVideo`
-		//  instead of `No such file or directory`
-		t.Error("Expected 'TranscoderInvalidVideo', got ", err)
-	}
-
 	// success # 1
 	in.Fname = "../transcoder/test.ts"
-	_, err = tc.Transcode(in, out)
+	_, err := tc.Transcode(in, out)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1217,27 +1208,6 @@ func audioOnlySegment(t *testing.T, accel Acceleration) {
 		}
 	}
 	tc.StopTranscoder()
-
-	// Test encoding with audio-only segment in start of stream
-	tc = NewTranscoder()
-	defer tc.StopTranscoder()
-	for i := 2; i < 4; i++ {
-		in := &TranscodeOptionsIn{
-			Fname: fmt.Sprintf("%s/test%d.ts", dir, i),
-			Accel: accel,
-		}
-		out := []TranscodeOptions{{
-			Oname:   fmt.Sprintf("%s/out2_%d.ts", dir, i),
-			Profile: prof,
-			Accel:   accel,
-		}}
-		_, err := tc.Transcode(in, out)
-		if i == 2 && (err == nil || err.Error() != "TranscoderInvalidVideo") {
-			t.Errorf("Expected to fail for audio-only segment but did not, instead got err=%v", err)
-		} else if i != 2 && err != nil {
-			t.Error(err)
-		}
-	}
 }
 
 func TestTranscoder_AudioOnly(t *testing.T) {

--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -8,7 +8,7 @@ static int is_mpegts(AVFormatContext *ic) {
   return !strcmp("mpegts", ic->iformat->name);
 }
 
-static int lpms_receive_frame(struct input_ctx *ictx, AVCodecContext *dec, AVFrame *frame)
+static int receive_frame(struct input_ctx *ictx, AVCodecContext *dec, AVFrame *frame)
 {
     int ret = avcodec_receive_frame(dec, frame);
     if (dec != ictx->vc) return ret;
@@ -53,7 +53,7 @@ int flush_in(struct input_ctx *ictx, AVFrame *frame, int *stream_index)
       ictx->flushed = 1;
       return ret;
     }
-    ret = lpms_receive_frame(ictx, ictx->vc, frame);
+    ret = receive_frame(ictx, ictx->vc, frame);
     *stream_index = ictx->vi;
     // Keep flushing if we haven't received all frames back but stop after SENTINEL_MAX tries.
     if (ictx->pkt_diff != 0 && ictx->sentinel_count <= SENTINEL_MAX && (!ret || ret == AVERROR(EAGAIN))) {

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -64,12 +64,11 @@ int demux_in(struct input_ctx *ictx, AVPacket *pkt);
 int decode_in(struct input_ctx *ictx, AVPacket *pkt, AVFrame *frame, int *stream_index);
 int flush_in(struct input_ctx *ictx, AVFrame *frame, int *stream_index);
 int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt, int *stream_index);
-enum AVPixelFormat hw2pixfmt(AVCodecContext *ctx);
 int open_input(input_params *params, struct input_ctx *ctx);
-int open_video_decoder(struct input_ctx *ctx, AVCodec *codec);
-int open_audio_decoder(struct input_ctx *ctx, AVCodec *codec);
-char* get_hw_decoder(int ff_codec_id, int hw_type);
 void free_input(struct input_ctx *inctx, enum FreeInputPolicy policy);
+// this should perhaps be moved to some utility file, as it is not decoder
+// specific
+enum AVPixelFormat hw2pixfmt(AVCodecContext *ctx);
 
 // Utility functions
 static inline int is_flush_frame(AVFrame *frame)

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -61,8 +61,8 @@ int flush_in(struct input_ctx *ictx, AVFrame *frame, int *stream_index);
 int process_in(struct input_ctx *ictx, AVFrame *frame, AVPacket *pkt, int *stream_index);
 enum AVPixelFormat hw2pixfmt(AVCodecContext *ctx);
 int open_input(input_params *params, struct input_ctx *ctx);
-int open_video_decoder(input_params *params, struct input_ctx *ctx);
-int open_audio_decoder(input_params *params, struct input_ctx *ctx);
+int open_video_decoder(struct input_ctx *ctx, AVCodec *codec);
+int open_audio_decoder(struct input_ctx *ctx, AVCodec *codec);
 char* get_hw_decoder(int ff_codec_id, int hw_type);
 void free_input(struct input_ctx *inctx);
 

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -10,6 +10,9 @@ struct input_ctx {
   AVFormatContext *ic; // demuxer required
   AVCodecContext  *vc; // video decoder optional
   AVCodecContext  *ac; // audo  decoder optional
+  // TODO: perhaps get rid of indices and introduce pointers same way as on
+  // the encoder side, easier to check and easier to dereference without
+  // pointer to demuxer
   int vi, ai; // video and audio stream indices
   int dv, da; // flags whether to drop video or audio
 

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -54,6 +54,11 @@ struct input_ctx {
   enum AVPixelFormat last_format;
 };
 
+enum FreeInputPolicy {
+  FORCE_CLOSE_HW_DECODER,
+  PRESERVE_HW_DECODER
+};
+
 // Exported methods
 int demux_in(struct input_ctx *ictx, AVPacket *pkt);
 int decode_in(struct input_ctx *ictx, AVPacket *pkt, AVFrame *frame, int *stream_index);
@@ -64,7 +69,7 @@ int open_input(input_params *params, struct input_ctx *ctx);
 int open_video_decoder(struct input_ctx *ctx, AVCodec *codec);
 int open_audio_decoder(struct input_ctx *ctx, AVCodec *codec);
 char* get_hw_decoder(int ff_codec_id, int hw_type);
-void free_input(struct input_ctx *inctx);
+void free_input(struct input_ctx *inctx, enum FreeInputPolicy policy);
 
 // Utility functions
 static inline int is_flush_frame(AVFrame *frame)

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -5,30 +5,59 @@
 #include <libavfilter/buffersrc.h>
 #include <libavfilter/buffersink.h>
 
+static AVStream *add_stream_copy(struct output_ctx *octx, AVStream *ist)
+{
+  int ret = 0;
+  if (!ist) LPMS_ERR(add_copy_err, "Input stream for copy not available");
+  AVStream *st = avformat_new_stream(octx->oc, NULL);
+  if (!st) LPMS_ERR(add_copy_err, "Unable to alloc copy stream");
+  st->time_base = ist->time_base;
+  ret = avcodec_parameters_copy(st->codecpar, ist->codecpar);
+  if (ret < 0) LPMS_ERR(add_copy_err, "Error copying params from input stream");
+  // Sometimes the codec tag is wonky for some reason, so correct it
+  ret = av_codec_get_tag2(octx->oc->oformat->codec_tag, st->codecpar->codec_id, &st->codecpar->codec_tag);
+  avformat_transfer_internal_stream_timing_info(octx->oc->oformat, st, ist, AVFMT_TBCF_DEMUXER);
+  return st;
+
+add_copy_err:
+  return NULL;
+}
+
+static AVStream *add_stream_for_encoder(struct output_ctx *octx, AVCodecContext *encoder)
+{
+  int ret = 0;
+  AVStream *st = avformat_new_stream(octx->oc, NULL);
+  if (!st) LPMS_ERR(add_encoder_err, "Unable to alloc encoder stream");
+
+  st->time_base = encoder->time_base;
+  ret = avcodec_parameters_from_context(st->codecpar, encoder);
+  if (ret < 0) LPMS_ERR(add_encoder_err, "Error setting stream params from encoder");
+  return st;
+
+add_encoder_err:
+  return NULL;
+}
+
 static int add_video_stream(struct output_ctx *octx, struct input_ctx *ictx)
 {
   // video stream to muxer
   int ret = 0;
-  AVStream *st = avformat_new_stream(octx->oc, NULL);
-  if (!st) LPMS_ERR(add_video_err, "Unable to alloc video stream");
-  octx->vi = st->index;
-  if (octx->fps.den) st->avg_frame_rate = octx->fps;
-  else st->avg_frame_rate = ictx->ic->streams[ictx->vi]->r_frame_rate;
+  AVStream *st = NULL;
   if (is_copy(octx->video->name)) {
-    // "copy block", identical in audio
-    AVStream *ist = ictx->ic->streams[ictx->vi];
-    if (ictx->vi < 0 || !ist) LPMS_ERR(add_video_err, "Input video stream does not exist");
-    st->time_base = ist->time_base;
-    ret = avcodec_parameters_copy(st->codecpar, ist->codecpar);
-    if (ret < 0) LPMS_ERR(add_video_err, "Error copying video params from input stream");
-    // Sometimes the codec tag is wonky for some reason, so correct it
-    ret = av_codec_get_tag2(octx->oc->oformat->codec_tag, st->codecpar->codec_id, &st->codecpar->codec_tag);
-    avformat_transfer_internal_stream_timing_info(octx->oc->oformat, st, ist, AVFMT_TBCF_DEMUXER);
+    // create stream as a copy of existing one
+    if (ictx->vi < 0) LPMS_ERR(add_video_err, "Input video stream does not exist");
+    st = add_stream_copy(octx, ictx->ic->streams[ictx->vi]);
+    if (!st) LPMS_ERR(add_video_err, "Error adding video copy stream");
+    octx->vi = st->index;
+    if (octx->fps.den) st->avg_frame_rate = octx->fps;
+    else st->avg_frame_rate = ictx->ic->streams[ictx->vi]->r_frame_rate;
   } else if (octx->vc) {
-    // "init from encoder" block, similar in audio but without time rescaling
-    st->time_base = octx->vc->time_base;
-    ret = avcodec_parameters_from_context(st->codecpar, octx->vc);
-    if (ret < 0) LPMS_ERR(add_video_err, "Error setting video params from encoder");
+    // create stream from encoder
+    st = add_stream_for_encoder(octx, octx->vc);
+    if (!st) LPMS_ERR(add_video_err, "Error adding video encoder stream");
+    octx->vi = st->index;
+    if (octx->fps.den) st->avg_frame_rate = octx->fps;
+    else st->avg_frame_rate = ictx->ic->streams[ictx->vi]->r_frame_rate;
     // Video has rescale here. Audio is slightly different
     // Rescale the gop/clip time to the expected timebase after filtering.
     // The FPS filter outputs pts incrementing by 1 at a rate of 1/framerate
@@ -48,7 +77,7 @@ static int add_video_stream(struct output_ctx *octx, struct input_ctx *ictx)
       octx->clip_to_pts = av_rescale_q(octx->clip_to, ms_tb, dest_tb);
     }
   } else if (is_drop(octx->video->name)) {
-    LPMS_ERR(add_video_err, "Shouldn't ever happen here");
+    LPMS_ERR(add_video_err, "add_video_stream called for dropped video!");
   } else LPMS_ERR(add_video_err, "No video encoder, not a copy; what is this?");
 
   octx->last_video_dts = AV_NOPTS_VALUE;
@@ -61,6 +90,7 @@ add_video_err:
 
 static int add_audio_stream(struct input_ctx *ictx, struct output_ctx *octx)
 {
+  // TODO: remove this? already handled in create_output
   if (ictx->ai < 0 || octx->da) {
     // Don't need to add an audio stream if no input audio exists,
     // or we're dropping the output audio stream
@@ -69,30 +99,25 @@ static int add_audio_stream(struct input_ctx *ictx, struct output_ctx *octx)
 
   // audio stream to muxer
   int ret = 0;
-  AVStream *st = avformat_new_stream(octx->oc, NULL);
-  if (!st) LPMS_ERR(add_audio_err, "Unable to alloc audio stream");
+  AVStream *st = NULL;
   if (is_copy(octx->audio->name)) {
-    // "copy block" identical in video
-    AVStream *ist = ictx->ic->streams[ictx->ai];
-    if (ictx->ai < 0 || !ist) LPMS_ERR(add_audio_err, "Input audio stream does not exist");
-    st->time_base = ist->time_base;
-    ret = avcodec_parameters_copy(st->codecpar, ist->codecpar);
-    if (ret < 0) LPMS_ERR(add_audio_err, "Error copying audio params from input stream");
-    // Sometimes the codec tag is wonky for some reason, so correct it
-    ret = av_codec_get_tag2(octx->oc->oformat->codec_tag, st->codecpar->codec_id, &st->codecpar->codec_tag);
-    avformat_transfer_internal_stream_timing_info(octx->oc->oformat, st, ist, AVFMT_TBCF_DEMUXER);
+    // create stream as a copy of existing one
+    if (ictx->ai < 0) LPMS_ERR(add_audio_err, "Input audio stream does not exist");
+    st = add_stream_copy(octx, ictx->ic->streams[ictx->ai]);
+    octx->ai = st->index;
   } else if (octx->ac) {
-    // "init from encoder" block, similar in video
-    st->time_base = octx->ac->time_base;
-    ret = avcodec_parameters_from_context(st->codecpar, octx->ac);
-    if (ret < 0) LPMS_ERR(add_audio_err, "Error setting audio params from encoder");
+    // create stream from encoder
+    st = add_stream_for_encoder(octx, octx->ac);
+    octx->ai = st->index;
     // Video has rescale here
   } else if (is_drop(octx->audio->name)) {
     // Supposed to exit this function early if there's a drop
-    LPMS_ERR(add_audio_err, "Shouldn't ever happen here");
+    LPMS_ERR(add_audio_err, "add_audio_stream called for dropped audio!");
   } else {
     LPMS_ERR(add_audio_err, "No audio encoder; not a copy; what is this?");
   }
+
+  if (!st) LPMS_ERR(add_audio_err, "Error adding video copy stream");
   octx->ai = st->index;
 
   // Audio has rescale here. Video version is slightly different
@@ -117,45 +142,17 @@ add_audio_err:
   return ret;
 }
 
-// TODO: try to find common ground between this function here and add_*_stream
-// Basically, there are two ways of adding streams. Copy or transmuxe way is
-// to just copy info coming from demultiplexer. The other way is to generate
-// the info using existing encoder (audio or video) which will have to be
-// abstracted away in the future (fe to allow CUDA nvenc to work with ffmpeg
-// muxer)
-// Also, there is the question which streams to add. For transmuxing all the
-// streams are copied (audio, video or else), otherwise up to one video and
-// up to one audio stream is copied
+// Add all streams provided by the demuxer. This is used in transmuxing
+// scenarios
 int add_remux_streams(struct input_ctx *ictx, struct output_ctx *octx)
 {
-  int ret = 0;
   octx->oc->flags |= AVFMT_FLAG_FLUSH_PACKETS;
   octx->oc->flush_packets = 1;
   for (int i = 0; i < ictx->ic->nb_streams; i++) {
-    ret = 0;
-    AVStream *st = avformat_new_stream(octx->oc, NULL);
-    if (!st) LPMS_ERR(add_remux_err, "Unable to alloc stream");
-    if (octx->fps.den)
-      st->avg_frame_rate = octx->fps;
-    else
-      st->avg_frame_rate = ictx->ic->streams[i]->r_frame_rate;
-
-    // very similar to "copy block" in the above add audio/video
-    AVStream *ist = ictx->ic->streams[i];
-    st->time_base = ist->time_base;
-    ret = avcodec_parameters_copy(st->codecpar, ist->codecpar);
-    if (ret < 0)
-      LPMS_ERR(add_remux_err, "Error copying params from input stream");
-    // Sometimes the codec tag is wonky for some reason, so correct it
-    ret = av_codec_get_tag2(octx->oc->oformat->codec_tag,
-                            st->codecpar->codec_id, &st->codecpar->codec_tag);
-    avformat_transfer_internal_stream_timing_info(octx->oc->oformat, st, ist,
-                                                  AVFMT_TBCF_DEMUXER);
-
+    AVStream *st = add_stream_copy(octx, ictx->ic->streams[i]);
+    if (!st) return -1; // error logged in add_stream_copy
   }
   return 0;
-add_remux_err:
-  return ret;
 }
 
 

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -240,7 +240,13 @@ video_encoder_err:
   return ret;
 }
 
-void close_output(struct output_ctx *octx)
+// This function is really the implementation of the free_output(), except that
+// it doesn't write trailer into the muxer. This is because trailer can only be
+// written if the header was written before - otherwise av_write_trailer() will
+// crash. Now, open_output() can fail somewhere between the begin of init work
+// and writing the header, hence the need for free_output() version without
+// writing the trailer. All other functions should use full version.
+static void free_output_no_trailer(struct output_ctx *octx, enum FreeOutputPolicy policy)
 {
   if (octx->oc) {
     if (!(octx->oc->oformat->flags & AVFMT_NOFILE) && octx->oc->pb) {
@@ -249,20 +255,41 @@ void close_output(struct output_ctx *octx)
     avformat_free_context(octx->oc);
     octx->oc = NULL;
   }
-  if (octx->vc && octx->hw_type == AV_HWDEVICE_TYPE_NONE) avcodec_free_context(&octx->vc);
+  if (octx->vc &&
+      ((octx->hw_type == AV_HWDEVICE_TYPE_NONE) || (FORCE_CLOSE_HW_ENCODER == policy))) {
+    avcodec_free_context(&octx->vc);
+  }
   if (octx->ac) avcodec_free_context(&octx->ac);
   octx->af.flushed = octx->vf.flushed = 0;
   octx->af.flushing = octx->vf.flushing = 0;
   octx->vf.pts_diff = INT64_MIN;
+  // TODO: this is a ugly hack. Basically, I believe that filters should be
+  // released/recreated every time (at least they are created again), but old
+  // code only close the vf filters on the lpms_transcode_stop, and it seems
+  // that retaining the filters has some effect on timestamps, so when new code
+  // started closing the video filter, TestTranscoderAPI_CountEncodedFrames
+  // was failing. And the fail had nothing to do with number of frames, just
+  // their timestamps were not the same as expected. I suppose new behavior is
+  // also correct, just different from what was hardcoded. So this is just a
+  // temporary solution to keep the test happy
+  // Update: as Ivan pointed out, some filters should be kept alive between
+  // segment, for example fps filter, or audio conversion filter, so for now
+  // I am expanding the hack to include audio filter as well
+  if (FORCE_CLOSE_HW_ENCODER == policy) {
+    free_filter(&octx->vf);
+    free_filter(&octx->af);
+  }
+  free_filter(&octx->sf);
 }
 
-void free_output(struct output_ctx *octx)
+// See comment on free_output_no_trailer() above
+void free_output(struct output_ctx *octx, enum FreeOutputPolicy policy)
 {
-  close_output(octx);
-  if (octx->vc) avcodec_free_context(&octx->vc);
-  free_filter(&octx->vf);
-  free_filter(&octx->af);
-  free_filter(&octx->sf);
+  // in this function it is safe to write trailer, since it is only called
+  // when muxer setup was succesful and header was written in the muxer
+  // doing otherwise causes crash in av_write_trailer
+  if (octx->oc) av_write_trailer(octx->oc);
+  free_output_no_trailer(octx, policy);
 }
 
 int open_output(struct output_ctx *octx, struct input_ctx *ictx)
@@ -325,18 +352,31 @@ int open_output(struct output_ctx *octx, struct input_ctx *ictx)
     if (ret < 0) LPMS_ERR(open_output_err, "Error opening output file");
   }
 
+  // IMPORTANT: notice how up to and including this point open_output_err is
+  // the error label. This is because free_output_no_trailer() is called there
+  // and it is actually the only place where we need that function. This is
+  // because avformat_write_trailer() which is called in free_output() will
+  // _crash_ if there wasn't corresponding avformat_write_header() call before.
+  // So up to the succesful completion of avformat_write_header() we need to
+  // call free_output_no_trailer() exclusively!
   ret = avformat_write_header(octx->oc, &octx->muxer->opts);
   if (ret < 0) LPMS_ERR(open_output_err, "Error writing header");
 
+  // From now on it is normal free_output(), hence after_header error label
   if(octx->sfilters != NULL && needs_decoder(octx->video->name) && octx->sf.active == 0) {
     ret = init_signature_filters(octx, NULL);
-    if (ret < 0) LPMS_ERR(open_output_err, "Unable to open signature filter");
+    if (ret < 0) LPMS_ERR(after_header_err, "Unable to open signature filter");
   }
 
   return 0;
 
 open_output_err:
-  free_output(octx);
+  // See comment above - here we have no header, so no trailer can be written
+  free_output_no_trailer(octx, FORCE_CLOSE_HW_ENCODER);
+  return ret;
+after_header_err:
+  // See comments above - header was written, we can finally call free_output()
+  free_output(octx, FORCE_CLOSE_HW_ENCODER);
   return ret;
 }
 

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -234,6 +234,7 @@ static int open_video_encoder(struct input_ctx *ictx, struct output_ctx *octx,
   }
   ret = avcodec_open2(vc, codec, &octx->video->opts);
   if (ret < 0) LPMS_ERR(video_encoder_err, "Error opening video encoder");
+  // TODO: move this up to open_output or similar
   octx->hw_type = ictx->hw_type;
 video_encoder_err:
   return ret;

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -276,7 +276,9 @@ int open_output(struct output_ctx *octx, struct input_ctx *ictx)
   if (!fmt) LPMS_ERR(open_output_err, "Unable to guess output format");
 
   // Encoders block - video and audio
-  // add video encoder if needed and don't have one yet
+  // add video encoder if needed and don't have one yet - this is because
+  // for HW contexts we do not destroy video encoder - see close_output()
+  // above for details
   if (ictx->vc && needs_decoder(octx->video->name) && !octx->vc) {
     ret = open_video_encoder(ictx, octx, fmt);
     if (ret < 0) LPMS_ERR(open_output_err, "Error opening video output");
@@ -287,6 +289,11 @@ int open_output(struct output_ctx *octx, struct input_ctx *ictx)
     ret = open_audio_encoder(ictx, octx, fmt);
     if (ret < 0) LPMS_ERR(open_output_err, "Error opening audio output");
   }
+
+  // If we have muxer, we don't have to proceed further. This is when doing
+  // transcoding, it won't be closed between the transcode calls to facilitate
+  // joining of several segments into one transmuxed output
+  if (octx->oc) return 0;
 
   // Now that the encoders are available, muxer can be created
   ret = avformat_alloc_output_context2(&octx->oc, fmt, NULL, octx->fname);

--- a/ffmpeg/encoder.h
+++ b/ffmpeg/encoder.h
@@ -5,9 +5,13 @@
 #include "transcoder.h"
 #include "filter.h"
 
+enum FreeOutputPolicy {
+  FORCE_CLOSE_HW_ENCODER,
+  PRESERVE_HW_ENCODER
+};
+
 int open_output(struct output_ctx *octx, struct input_ctx *ictx);
-void close_output(struct output_ctx *octx);
-void free_output(struct output_ctx *octx);
+void free_output(struct output_ctx *octx, enum FreeOutputPolicy);
 int process_out(struct input_ctx *ictx, struct output_ctx *octx, AVCodecContext *encoder, AVStream *ost,
   struct filter_ctx *filter, AVFrame *inf);
 int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost);

--- a/ffmpeg/encoder.h
+++ b/ffmpeg/encoder.h
@@ -6,7 +6,6 @@
 #include "filter.h"
 
 int open_output(struct output_ctx *octx, struct input_ctx *ictx);
-int reopen_output(struct output_ctx *octx, struct input_ctx *ictx);
 void close_output(struct output_ctx *octx);
 void free_output(struct output_ctx *octx);
 int process_out(struct input_ctx *ictx, struct output_ctx *octx, AVCodecContext *encoder, AVStream *ost,

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -1018,7 +1018,7 @@ func (t *Transcoder) Discontinuity() {
 
 func NewTranscoder() *Transcoder {
 	return &Transcoder{
-		handle: C.lpms_transcode_new(),
+		handle: C.lpms_transcode_new(nil),
 		mu:     &sync.Mutex{},
 	}
 }
@@ -1071,7 +1071,7 @@ func NewTranscoderWithDetector(detector DetectorProfile, deviceid string) (*Tran
 		defer C.free(unsafe.Pointer(dnnOpt.inputname))
 		defer C.free(unsafe.Pointer(dnnOpt.outputname))
 		defer C.free(unsafe.Pointer(dnnOpt.backend_configs))
-		handle := C.lpms_transcode_new_with_dnn(dnnOpt)
+		handle := C.lpms_transcode_new(dnnOpt)
 		if handle != nil {
 			return &Transcoder{
 				handle: handle,

--- a/ffmpeg/ffmpeg_errors.go
+++ b/ffmpeg/ffmpeg_errors.go
@@ -17,6 +17,7 @@ var lpmsErrors = []struct {
 	{Code: C.lpms_ERR_INPUT_PIXFMT, Desc: "Unsupported input pixel format"},
 	{Code: C.lpms_ERR_FILTERS, Desc: "Error initializing filtergraph"},
 	{Code: C.lpms_ERR_OUTPUTS, Desc: "Too many outputs"},
+  {Code: C.lpms_ERR_INPUTS, Desc: "No input configuration"},
 	{Code: C.lpms_ERR_INPUT_CODEC, Desc: "Unsupported input codec"},
 	{Code: C.lpms_ERR_INPUT_NOKF, Desc: "No keyframes in input"},
 	{Code: C.lpms_ERR_UNRECOVERABLE, Desc: "Unrecoverable state, restart process"},

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -871,17 +871,6 @@ func TestTranscoder_StreamCopy(t *testing.T) {
 	if res.Decoded.Frames != 0 || res.Encoded[0].Frames != 0 {
 		t.Error("Unexpected count of decoded/encoded frames")
 	}
-	in = &TranscodeOptionsIn{Fname: dir + "/audioonly.ts"}
-	out = []TranscodeOptions{
-		{
-			Oname:        dir + "/noaudio.ts",
-			Profile:      P144p30fps16x9,
-			AudioEncoder: ComponentOptions{Name: "copy"},
-		},
-	}
-	// Audio only segments are not supported
-	_, err = Transcode3(in, out)
-	assert.EqualError(t, err, "TranscoderInvalidVideo")
 }
 
 func TestTranscoder_StreamCopy_Validate_B_Frames(t *testing.T) {
@@ -1010,11 +999,6 @@ func TestTranscoder_Drop(t *testing.T) {
 	if res.Decoded.Frames != 30 || res.Encoded[0].Frames != 30 {
 		t.Error("Unexpected encoded/decoded frame counts ", res.Decoded.Frames, res.Encoded[0].Frames)
 	}
-	in.Fname = dir + "/novideo.ts"
-	out = []TranscodeOptions{{Oname: dir + "/encoded-audio.mp4", Profile: P144p30fps16x9}}
-	_, err = Transcode3(in, out)
-	// Audio only segments are not supported
-	assert.EqualError(t, err, "TranscoderInvalidVideo")
 }
 
 func TestTranscoder_StreamCopyAndDrop(t *testing.T) {

--- a/ffmpeg/filter.h
+++ b/ffmpeg/filter.h
@@ -45,7 +45,8 @@ struct output_ctx {
   AVFormatContext *oc; // muxer required
   AVCodecContext  *vc; // video decoder optional
   AVCodecContext  *ac; // audo  decoder optional
-  int vi, ai; // video and audio stream indices
+  AVStream *audio_stream;
+  AVStream *video_stream;
   int dv, da; // flags whether to drop video or audio
   struct filter_ctx vf, af, sf;
 

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -718,7 +718,8 @@ create_dnn_error:
   return NULL;
 }
 
-struct transcode_thread* lpms_transcode_new() {
+struct transcode_thread* lpms_transcode_new(lvpdnn_opts *dnn_opts)
+{
   struct transcode_thread *h = malloc(sizeof (struct transcode_thread));
   if (!h) return NULL;
   memset(h, 0, sizeof *h);
@@ -729,22 +730,15 @@ struct transcode_thread* lpms_transcode_new() {
   for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
     h->ictx.last_dts[i] = -1;
   }
-  return h;
-}
-
-// TODO: perhaps could merge together with previous one, giving NULL as
-// dnn_opts when dnn filtergraph is not desired
-struct transcode_thread* lpms_transcode_new_with_dnn(lvpdnn_opts *dnn_opts)
-{
-  struct transcode_thread *h = malloc(sizeof (struct transcode_thread));
-  if (!h) return NULL;
-  memset(h, 0, sizeof *h);
-  AVFilterGraph *filtergraph = create_dnn_filtergraph(dnn_opts);
-  if (!filtergraph) {
+  // handle dnn filter graph creation
+  if (dnn_opts) {
+    AVFilterGraph *filtergraph = create_dnn_filtergraph(dnn_opts);
+    if (!filtergraph) {
       free(h);
       h = NULL;
-  } else {
+    } else {
       h->dnn_filtergraph = filtergraph;
+    }
   }
   return h;
 }

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -290,6 +290,7 @@ int handle_audio_frame(struct transcode_thread *h, AVStream *ist, output_results
 {
   struct input_ctx *ictx = &h->ictx;
 
+  ++decoded_results->audio_frames;
   // frame duration update
   int64_t dur = 0;
   if (dframe->pkt_duration) {
@@ -324,11 +325,12 @@ int handle_video_frame(struct transcode_thread *h, AVStream *ist, output_results
 {
   struct input_ctx *ictx = &h->ictx;
 
-  // TODO: this was removed, but need to investigate if safe
-  //    if (is_flush_frame(dframe)) goto whileloop_end;
+  // MA: "sentinel frames" stuff, will be removed
+  if (is_flush_frame(dframe)) return 0;
   // if we are here, we know there is a frame
   ++decoded_results->frames;
   decoded_results->pixels += dframe->width * dframe->height;
+  ++decoded_results->video_frames;
 
   // frame duration update
   int64_t dur = 0;
@@ -364,6 +366,7 @@ int handle_video_frame(struct transcode_thread *h, AVStream *ist, output_results
 int handle_audio_packet(struct transcode_thread *h, output_results *decoded_results,
                         AVPacket *pkt, AVFrame *frame)
 {
+  ++decoded_results->audio_packets;
   // Packet processing part
   struct input_ctx *ictx = &h->ictx;
   AVStream *ist = ictx->ic->streams[pkt->stream_index];
@@ -401,6 +404,7 @@ int handle_audio_packet(struct transcode_thread *h, output_results *decoded_resu
           octx->clip_audio_start_pts = pkt->pts;
           octx->clip_audio_start_pts_found = 1;
         }
+        // similar to clipping in encoder.c
         if (octx->clip_to && octx->clip_audio_start_pts_found && pkt->pts > octx->clip_audio_to_pts + octx->clip_audio_start_pts) {
           continue;
         }
@@ -420,6 +424,7 @@ int handle_audio_packet(struct transcode_thread *h, output_results *decoded_resu
       ret = mux(opkt, ist->time_base, octx, ost);
       av_packet_free(&opkt);
       if (ret < 0) LPMS_ERR_RETURN("Audio packet muxing error");
+      ++octx->res->audio_packets;
     }
   }
 
@@ -449,6 +454,7 @@ int handle_audio_packet(struct transcode_thread *h, output_results *decoded_resu
 int handle_video_packet(struct transcode_thread *h, output_results *decoded_results,
                         AVPacket *pkt, AVFrame *frame)
 {
+  ++decoded_results->video_packets;
   // Packet processing part
   struct input_ctx *ictx = &h->ictx;
   AVStream *ist = ictx->ic->streams[pkt->stream_index];
@@ -495,6 +501,7 @@ int handle_video_packet(struct transcode_thread *h, output_results *decoded_resu
       ret = mux(opkt, ist->time_base, octx, ost);
       av_packet_free(&opkt);
       if (ret < 0) LPMS_ERR_RETURN("Video packet muxing error");
+      ++octx->res->video_packets;
     }
   }
 
@@ -520,7 +527,7 @@ int handle_video_packet(struct transcode_thread *h, output_results *decoded_resu
     // TODO: this whole sentinel frame business and packet count is broken,
     // because it assumes 1-to-1 relationship between packets and frames, and
     // it won't be so in multislice streams. Also what if first packet is just
-    // parameter set and encoder doesn't have to decode when receiving one
+    // parameter set? the decoder doesn't have to decode when receiving one
     if (!is_flush_frame(frame)) {
       ictx->pkt_diff--; // decrease buffer count for non-sentinel video frames
       if (ictx->flushing) ictx->sentinel_count = 0;
@@ -530,8 +537,10 @@ int handle_video_packet(struct transcode_thread *h, output_results *decoded_resu
   }
 }
 
-int handle_other_packet(struct transcode_thread *h, AVPacket *pkt)
+int handle_other_packet(struct transcode_thread *h,
+                        output_results *decoded_results, AVPacket *pkt)
 {
+  ++decoded_results->other_packets;
   struct input_ctx *ictx = &h->ictx;
   AVStream *ist = ictx->ic->streams[pkt->stream_index];
   int ret = 0;
@@ -557,6 +566,7 @@ int handle_other_packet(struct transcode_thread *h, AVPacket *pkt)
       ret = mux(opkt, ist->time_base, octx, ost);
       av_packet_free(&opkt);
       if (ret < 0) LPMS_ERR_RETURN("Other packet muxing error");
+      ++octx->res->other_packets;
     }
   }
 
@@ -591,7 +601,7 @@ int flush_all_outputs(struct transcode_thread *h)
   return 0;
 }
 
-int transcode2(struct transcode_thread *h,
+int transcode(struct transcode_thread *h,
   input_params *inp, output_params *params,
   output_results *decoded_results)
 {
@@ -607,7 +617,7 @@ int transcode2(struct transcode_thread *h,
 
   // Main demuxing loop: process input packets till EOF in the input stream
   while (1) {
-    ret = demux_in(ictx, ipkt);
+    ret = av_read_frame(ictx->ic, ipkt);
     // See what we got
     if (ret == AVERROR_EOF) {
       // no more input packets
@@ -628,7 +638,7 @@ int transcode2(struct transcode_thread *h,
       if (ret < 0) break;
     } else {
       // other types of packets (used only for transmuxing)
-      handle_other_packet(h, ipkt);
+      handle_other_packet(h, decoded_results, ipkt);
       if (ret < 0) break;
     }
     av_packet_unref(ipkt);
@@ -664,13 +674,12 @@ int transcode2(struct transcode_thread *h,
   // be frames buffered in the filters, and we need to flush them
   // IMPORTANT: no handle_*_frame calls here because there is no more input
   // frames.
-  // NOTE: this is "flush filters, flush decoders, flush muxers" all in one,
+  // NOTE: this is "flush filters, flush encoders, flush muxers" all in one,
   // it will get broken down in future
   flush_all_outputs(h);
 
   // Processing finished
 
-transcode_cleanup:
   if (ipkt) av_packet_free(&ipkt);
   if (iframe) av_frame_free(&iframe);
 
@@ -684,218 +693,10 @@ transcode_cleanup:
   } else return transcode_shutdown(h, ret);
 }
 
-int transcode(struct transcode_thread *h,
-  input_params *inp, output_params *params,
-  output_results *decoded_results)
-{
-  int ret = 0;
-  AVPacket *ipkt = NULL;
-  AVFrame *dframe = NULL;
-  struct input_ctx *ictx = &h->ictx;
-  struct output_ctx *outputs = h->outputs;
-  int nb_outputs = h->nb_outputs;
-
-  ipkt = av_packet_alloc();
-  if (!ipkt) LPMS_ERR(transcode_cleanup, "Unable to allocated packet");
-  dframe = av_frame_alloc();
-  if (!dframe) LPMS_ERR(transcode_cleanup, "Unable to allocate frame");
-
-  while (1) {
-    // DEMUXING & DECODING
-    int has_frame = 0;
-    AVStream *ist = NULL;
-    AVFrame *last_frame = NULL;
-    int stream_index = -1;
-
-    av_frame_unref(dframe);
-    ret = process_in(ictx, dframe, ipkt, &stream_index);
-    if (ret == AVERROR_EOF) {
-      // no more processing, go for flushes
-      break;
-    }
-    else if (lpms_ERR_PACKET_ONLY == ret) ; // keep going for stream copy
-    else if (ret == AVERROR(EAGAIN)) ;  // this is a-ok
-    else if (lpms_ERR_INPUT_NOKF == ret) {
-      LPMS_ERR(transcode_cleanup, "Could not decode; No keyframes in input");
-    } else if (ret < 0) LPMS_ERR(transcode_cleanup, "Could not decode; stopping");
-
-    // So here we have several possibilities:
-    // ipkt: usually it will be here, but if we are decoding, and if we reached
-    // end of stream, it may be so that draining of the decoder produces frames
-    // without packets
-    // dframe: if there is no decoding (because of transmuxing, or because of
-    // copying), it won't be set
-
-    ist = ictx->ic->streams[stream_index];
-
-    // This is for the case when we _are_ decoding but frame is not complete yet
-    // So for example multislice h.264 picture without all slices fed in.
-    // IMPORTANT: this should also be false if we are transmuxing, and it is not
-    // so, at least not automatically, because then process_in returns 0 and not
-    // lpms_ERR_PACKET_ONLY
-    has_frame = lpms_ERR_PACKET_ONLY != ret;
-
-    // Now apart from if (is_flush_frame(dframe)) goto whileloop_end; statement
-    // this code just updates has_frame properly for video and audio, updates
-    // statistics for video and ausio and sets last_frame
-    if (AVMEDIA_TYPE_VIDEO == ist->codecpar->codec_type) {
-      if (is_flush_frame(dframe)) goto whileloop_end;
-      // width / height will be zero for pure streamcopy (no decoding)
-      decoded_results->frames += dframe->width && dframe->height;
-      decoded_results->pixels += dframe->width * dframe->height;
-      has_frame = has_frame && dframe->width && dframe->height;
-      if (has_frame) last_frame = ictx->last_frame_v;
-    } else if (AVMEDIA_TYPE_AUDIO == ist->codecpar->codec_type) {
-      has_frame = has_frame && dframe->nb_samples;
-      if (has_frame) last_frame = ictx->last_frame_a;
-    } else {
-      has_frame = 0;  // bugfix
-    }
-    // if there is frame, update duration and put this frame in place as last_frame
-    if (has_frame) {
-      int64_t dur = 0;
-      if (dframe->pkt_duration) dur = dframe->pkt_duration;
-      else if (ist->r_frame_rate.den) {
-        dur = av_rescale_q(1, av_inv_q(ist->r_frame_rate), ist->time_base);
-      } else {
-        // TODO use better heuristics for this; look at how ffmpeg does it
-        LPMS_WARN("Could not determine next pts; filter might drop");
-      }
-      dframe->pkt_duration = dur;
-      av_frame_unref(last_frame);
-      av_frame_ref(last_frame, dframe);
-    }
-    // similar but for transmuxing case - update number of frames
-    if (ictx->transmuxing) {
-      if (AVMEDIA_TYPE_VIDEO == ist->codecpar->codec_type) {
-        decoded_results->frames++;  // Michal: this is packets, not frames, may be wrong with multislice!
-      }
-      if (stream_index < MAX_OUTPUT_SIZE) {
-        if (ictx->discontinuity[stream_index]) {
-          // calc dts diff
-          ictx->dts_diff[stream_index] = ictx->last_dts[stream_index] + ictx->last_duration[stream_index] - ipkt->dts;
-          ictx->discontinuity[stream_index] = 0;
-        }
-        ipkt->pts += ictx->dts_diff[stream_index];
-        ipkt->dts += ictx->dts_diff[stream_index];
-        // Michal: this is dangerous, may damage the stream due to dropping critical
-        // packet - one could do that to frames, but not packets. Some formats
-        // allow dropping packets (like nonref picture slices in h.264 or frames
-        // other than keyframes in vp8), but it needs to be done with care and
-        // understanding of the packet role, not arbitrarily
-        if (ictx->last_dts[stream_index] > -1 && ipkt->dts <= ictx->last_dts[stream_index])  {
-          // skip packet if dts is equal or less than previous one
-          goto whileloop_end;
-        }
-        ictx->last_dts[stream_index] = ipkt->dts;
-        if (ipkt->duration) {
-          ictx->last_duration[stream_index] = ipkt->duration;
-        }
-      }
-    }
-
-    // ENCODING & MUXING OF ALL OUTPUT RENDITIONS
-    for (int i = 0; i < nb_outputs; i++) {
-      struct output_ctx *octx = &outputs[i];
-      struct filter_ctx *filter = NULL;
-      AVStream *ost = NULL;
-      AVCodecContext *encoder = NULL;
-      ret = 0; // reset to avoid any carry-through
-
-      if (ictx->transmuxing)
-        ost = octx->oc->streams[stream_index];  // because all streams are copied 1:1
-      else if (ist->index == ictx->vi) {
-        if (octx->dv) continue; // drop video stream for this output
-        ost = octx->oc->streams[0]; // because video stream is always stream 0
-        if (ictx->vc) {
-          encoder = octx->vc;
-          filter = &octx->vf;
-        }
-      } else if (ist->index == ictx->ai) {
-        if (octx->da) continue; // drop audio stream for this output
-        ost = octx->oc->streams[octx->dv ? 0 : 1]; // audio index depends on whether video exists
-        if (ictx->ac) {
-          encoder = octx->ac;
-          filter = &octx->af;
-        }
-      } else continue; // dropped or unrecognized stream
-
-      if (!encoder && ost) {
-        // stream copy
-        AVPacket *pkt;
-
-        // we hit this case when decoder is flushing; will be no input packet
-        // (we don't need decoded frames since this stream is doing a copy)
-        if (ipkt->pts == AV_NOPTS_VALUE) continue;
-
-        if (ist->index == ictx->ai) {
-          if (!octx->clip_audio_start_pts_found) {
-            octx->clip_audio_start_pts = ipkt->pts;
-            octx->clip_audio_start_pts_found = 1;
-          }
-          if (octx->clip_to && octx->clip_audio_start_pts_found && ipkt->pts > octx->clip_audio_to_pts + octx->clip_audio_start_pts) {
-            continue;
-          }
-          if (octx->clip_from && !octx->clip_started) {
-            // we want first frame to be video frame
-            continue;
-          }
-          if (octx->clip_from && ipkt->pts < octx->clip_audio_from_pts + octx->clip_audio_start_pts) {
-            continue;
-          }
-        }
-
-        pkt = av_packet_clone(ipkt);
-        if (!pkt) LPMS_ERR(transcode_cleanup, "Error allocating packet for copy");
-        if (octx->clip_from && ist->index == ictx->ai) {
-          pkt->pts -= octx->clip_audio_from_pts + octx->clip_audio_start_pts;
-        }
-        ret = mux(pkt, ist->time_base, octx, ost);
-        av_packet_free(&pkt);
-      } else if (has_frame) {
-        ret = process_out(ictx, octx, encoder, ost, filter, dframe);
-      }
-      if (AVERROR(EAGAIN) == ret || AVERROR_EOF == ret) continue;
-      else if (ret < 0) LPMS_ERR(transcode_cleanup, "Error encoding");
-    }
-whileloop_end:
-    av_packet_unref(ipkt);
-  }
-
-  if (ictx->transmuxing) {
-    for (int i = 0; i < nb_outputs; i++) {
-      av_interleaved_write_frame(outputs[i].oc, NULL); // flush muxer
-    }
-    if (ictx->ic) {
-        avformat_close_input(&ictx->ic);
-        ictx->ic = NULL;
-    }
-    return 0;
-  }
-
-  // flush outputs
-  for (int i = 0; i < nb_outputs; i++) {
-    if(outputs[i].is_dnn_profile == 0/* && outputs[i].has_output > 0*/) {
-      ret = flush_outputs(ictx, &outputs[i]);
-      if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to fully flush outputs")
-    }
-    else if(outputs[i].is_dnn_profile && outputs[i].res->frames > 0) {
-       for (int j = 0; j < MAX_CLASSIFY_SIZE; j++) {
-         outputs[i].res->probs[j] =  outputs[i].res->probs[j] / outputs[i].res->frames;
-       }
-    }
-  }
-
-transcode_cleanup:
-  if (dframe) av_frame_free(&dframe);
-  if (ipkt) av_packet_free(&ipkt);  // needed for early exits
-  return transcode_shutdown(h, ret);
-}
-
 // MA: this should probably be merged with transcode_init, as it basically is a
 // part of initialization
 int lpms_transcode(input_params *inp, output_params *params,
-  output_results *results, int nb_outputs, output_results *decoded_results, int use_new)
+  output_results *results, int nb_outputs, output_results *decoded_results)
 {
   int ret = 0;
   struct transcode_thread *h = inp->handle;
@@ -959,12 +760,7 @@ int lpms_transcode(input_params *inp, output_params *params,
 
   ret = transcode_init(h, inp, params, results);
   if (ret < 0) return ret;
-
-  if (use_new) {
-    ret = transcode2(h, inp, params, decoded_results);
-  } else {
-    ret = transcode(h, inp, params, decoded_results);
-  }
+  ret = transcode(h, inp, params, decoded_results);
   h->initialized = 1;
   return ret;
 }

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -140,11 +140,14 @@ int transcode_shutdown(struct transcode_thread *h, int ret)
   if (ictx->vc && (AV_HWDEVICE_TYPE_NONE == ictx->hw_type)) avcodec_free_context(&ictx->vc);
   for (int i = 0; i < nb_outputs; i++) {
     //send EOF signal to signature filter
-    if(outputs[i].sfilters != NULL && outputs[i].sf.src_ctx != NULL) {
+    if (outputs[i].sfilters != NULL && outputs[i].sf.src_ctx != NULL) {
       av_buffersrc_close(outputs[i].sf.src_ctx, AV_NOPTS_VALUE, AV_BUFFERSRC_FLAG_PUSH);
       free_filter(&outputs[i].sf);
     }
-    close_output(&outputs[i]);
+    // TODO: one day this will be per-output setting and not a global one
+    if (!ictx->transmuxing) {
+      close_output(&outputs[i]);
+    }
   }
   return ret == AVERROR_EOF ? 0 : ret;
 
@@ -228,18 +231,8 @@ int transcode_init(struct transcode_thread *h, input_params *inp,
     octx->da = ictx->ai < 0 || is_drop(octx->audio->name);
     octx->res = &results[i];
 
-    // first segment of a stream, need to initalize output HW context
-    // XXX valgrind this line up
-    // when transmuxing we're opening output with first segment, but closing it
-    // only when lpms_transcode_stop called, so we don't want to re-open it
-    // on subsequent segments
-    // TODO: basically this means "open every time, unless we are transmuxing
-    // and output muxer remains open". Which should be moved into open_output()
-    // anyway...
-    if (!h->initialized || !ictx->transmuxing) {
-      ret = open_output(octx, ictx);
-      if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to open output");
-    }
+    ret = open_output(octx, ictx);
+    if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to open output");
   }
 
   return 0;   // all ok
@@ -671,18 +664,10 @@ int transcode(struct transcode_thread *h,
   flush_all_outputs(h);
 
   // Processing finished
-
   if (ipkt) av_packet_free(&ipkt);
   if (iframe) av_frame_free(&iframe);
 
-  if (ictx->transmuxing) {
-    // transcode_shutdown() is not to be called when transmuxing
-    if (ictx->ic) {
-        avformat_close_input(&ictx->ic);
-        ictx->ic = NULL;
-    }
-    return 0;
-  } else return transcode_shutdown(h, ret);
+  return transcode_shutdown(h, ret);
 }
 
 // MA: this should probably be merged with transcode_init, as it basically is a
@@ -762,20 +747,6 @@ int lpms_transcode_reopen_demux(input_params *inp) {
   return open_input(inp, &inp->handle->ictx);
 }
 
-struct transcode_thread* lpms_transcode_new() {
-  struct transcode_thread *h = malloc(sizeof (struct transcode_thread));
-  if (!h) return NULL;
-  memset(h, 0, sizeof *h);
-  // initialize video stream pixel format.
-  h->ictx.last_format = AV_PIX_FMT_NONE;
-  // keep track of last dts in each stream.
-  // used while transmuxing, to skip packets with invalid dts.
-  for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
-    h->ictx.last_dts[i] = -1;
-  }
-  return h;
-}
-
 void lpms_transcode_stop(struct transcode_thread *handle) {
   // not threadsafe as-is; calling function must ensure exclusivity!
 
@@ -836,6 +807,22 @@ create_dnn_error:
   return NULL;
 }
 
+struct transcode_thread* lpms_transcode_new() {
+  struct transcode_thread *h = malloc(sizeof (struct transcode_thread));
+  if (!h) return NULL;
+  memset(h, 0, sizeof *h);
+  // initialize video stream pixel format.
+  h->ictx.last_format = AV_PIX_FMT_NONE;
+  // keep track of last dts in each stream.
+  // used while transmuxing, to skip packets with invalid dts.
+  for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
+    h->ictx.last_dts[i] = -1;
+  }
+  return h;
+}
+
+// TODO: perhaps could merge together with previous one, giving NULL as
+// dnn_opts when dnn filtergraph is not desired
 struct transcode_thread* lpms_transcode_new_with_dnn(lvpdnn_opts *dnn_opts)
 {
   struct transcode_thread *h = malloc(sizeof (struct transcode_thread));

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -53,7 +53,7 @@ typedef struct {
   char *xcoderParams;
 
   // Optional video decoder + opts
-  component_opts video;
+//  component_opts video;
 
   int transmuxe;
 } input_params;

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -98,7 +98,6 @@ enum LPMSLogLevel {
 
 void lpms_init(enum LPMSLogLevel max_level);
 int lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
-int lpms_transcode_reopen_demux(input_params *inp);
 struct transcode_thread* lpms_transcode_new(lvpdnn_opts *dnn_opts);
 void lpms_transcode_stop(struct transcode_thread* handle);
 void lpms_transcode_discontinuity(struct transcode_thread *handle);

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -16,6 +16,7 @@ extern const int lpms_ERR_FILTERS;
 extern const int lpms_ERR_PACKET_ONLY;
 extern const int lpms_ERR_FILTER_FLUSHED;
 extern const int lpms_ERR_OUTPUTS;
+extern const int lpms_ERR_INPUTS;
 extern const int lpms_ERR_UNRECOVERABLE;
 
 struct transcode_thread;

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -75,6 +75,12 @@ typedef struct {
     int64_t pixels;
     //for scene classification  
     float probs[MAX_CLASSIFY_SIZE];//probability
+    // new stats
+    int video_frames;
+    int audio_frames;
+    int video_packets;
+    int audio_packets;
+    int other_packets;
 } output_results;
 
 enum LPMSLogLevel {
@@ -90,7 +96,7 @@ enum LPMSLogLevel {
 };
 
 void lpms_init(enum LPMSLogLevel max_level);
-int lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results, int use_new);
+int lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
 int lpms_transcode_reopen_demux(input_params *inp);
 struct transcode_thread* lpms_transcode_new();
 struct transcode_thread* lpms_transcode_new_with_dnn(lvpdnn_opts *dnn_opts);

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -99,8 +99,7 @@ enum LPMSLogLevel {
 void lpms_init(enum LPMSLogLevel max_level);
 int lpms_transcode(input_params *inp, output_params *params, output_results *results, int nb_outputs, output_results *decoded_results);
 int lpms_transcode_reopen_demux(input_params *inp);
-struct transcode_thread* lpms_transcode_new();
-struct transcode_thread* lpms_transcode_new_with_dnn(lvpdnn_opts *dnn_opts);
+struct transcode_thread* lpms_transcode_new(lvpdnn_opts *dnn_opts);
 void lpms_transcode_stop(struct transcode_thread* handle);
 void lpms_transcode_discontinuity(struct transcode_thread *handle);
 

--- a/ffmpeg/transmuxer_test.go
+++ b/ffmpeg/transmuxer_test.go
@@ -50,6 +50,18 @@ func TestTransmuxer_Pipe(t *testing.T) {
 	}
 }
 
+// IMPORTANT: this test was originally checking "Frames" statistics from C code
+// of the Transcoder. "Frames" were increased on every video frame (when in
+// transcoding mode) and on every video _packet_ (when in transmuxing mode).
+// This could be misleading for modern codecs which don't necessarily have
+// direct 1 to 1 relationship between video packets and video frames, and so
+// was changed to separate count for audio/video frames, and audio/video/other
+// packet types.
+// Tests here were changed to pick up "video packets", because that was the
+// original authors intention (again, original transcoder updated "Frames" count
+// on every video packet while transmuxing). Remaining terminology, such as
+// getting the number of video _frames_ (not packets) via ffprobe remains the
+// same, since for given test streams it all adds up
 func TestTransmuxer_Join(t *testing.T) {
 	run, dir := setupTest(t)
 	defer os.RemoveAll(dir)
@@ -90,8 +102,8 @@ func TestTransmuxer_Join(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if res.Decoded.Frames != 120 {
-			t.Error(in.Fname, " Mismatched frame count: expected 120 got ", res.Decoded.Frames)
+		if res.Decoded.VideoPackets != 120 {
+			t.Error(in.Fname, " Mismatched video packet count: expected 120 got ", res.Decoded.VideoPackets)
 		}
 	}
 	tc.StopTranscoder()
@@ -141,8 +153,8 @@ func TestTransmuxer_Discontinuity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if res.Decoded.Frames != 120 {
-			t.Error(in.Fname, " Mismatched frame count: expected 120 got ", res.Decoded.Frames)
+		if res.Decoded.VideoPackets != 120 {
+			t.Error(in.Fname, " Mismatched video packet count: expected 120 got ", res.Decoded.VideoPackets)
 		}
 	}
 	tc.Discontinuity()
@@ -155,8 +167,8 @@ func TestTransmuxer_Discontinuity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if res.Decoded.Frames != 120 {
-			t.Error(in.Fname, " Mismatched frame count: expected 120 got ", res.Decoded.Frames)
+		if res.Decoded.VideoPackets != 120 {
+			t.Error(in.Fname, " Mismatched video packet count: expected 120 got ", res.Decoded.VideoPackets)
 		}
 	}
 


### PR DESCRIPTION
This set of changes is about two things:
- First, obvious follow-up to a first batch of changes, like removal of old transcode() function implementation, removing code that is no longer needed because only old transcode() used it, and so on and so forth
- Second, I was focusing on input/output sanitisation. The idea was to take bits and pieces of code that was scattered here and there, and slowly push it towards single open_input/close_input and open_output/close_output functions. It was surprisingly hard to achieve, and there were a lot of edge cases but it is done now. Justification for this approach was not only generic "make code better" angle of approach, but also a need to create groundwork for LL changes. Basically, if we are to plug into FFmpeg I/O internals it is so much easier to do if there is reasonable, single I/O flow to begin with.