### PR TITLE
change video comparison function

### DIFF
--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -30,7 +30,7 @@ struct input_ctx {
   // We maintain a count of sentinel packets sent without receiving any
   // valid frames back, and stop flushing if it crosses SENTINEL_MAX.
   // FIXME This is needed due to issue #155 - input/output frame mismatch.
-#define SENTINEL_MAX 5
+#define SENTINEL_MAX 8
   uint16_t sentinel_count;
 
   // Filter flush

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -393,7 +393,7 @@ int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost)
   //     hasn't been a problem in practice (so far)
   if (AVMEDIA_TYPE_AUDIO == ost->codecpar->codec_type) {
       if (octx->drop_ts == AV_NOPTS_VALUE) octx->drop_ts = pkt->pts;
-      if (!is_copy(octx->audio->name) && pkt->pts && pkt->pts == octx->drop_ts) return 0;
+      if (pkt->pts && pkt->pts == octx->drop_ts) return 0;
 
       if (pkt->dts != AV_NOPTS_VALUE && pkt->pts != AV_NOPTS_VALUE && pkt->dts > pkt->pts) {
         pkt->pts = pkt->dts = pkt->pts + pkt->dts + octx->last_audio_dts + 1

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -393,7 +393,7 @@ int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost)
   //     hasn't been a problem in practice (so far)
   if (AVMEDIA_TYPE_AUDIO == ost->codecpar->codec_type) {
       if (octx->drop_ts == AV_NOPTS_VALUE) octx->drop_ts = pkt->pts;
-      if (pkt->pts && pkt->pts == octx->drop_ts) return 0;
+      if (!is_copy(octx->audio->name) && pkt->pts && pkt->pts == octx->drop_ts) return 0;
 
       if (pkt->dts != AV_NOPTS_VALUE && pkt->pts != AV_NOPTS_VALUE && pkt->dts > pkt->pts) {
         pkt->pts = pkt->dts = pkt->pts + pkt->dts + octx->last_audio_dts + 1

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -341,7 +341,7 @@ static int get_matchinfo(void *buffer, int len, struct match_info* info)
     }
     info->packetcount++;
     info->timestamp ^= packet->pts;
-    if(packet->stream_index == audioid && packet->size > 0) {
+    if(packet->stream_index == audioid && packet->pts > 0 && packet->size > 0) {
       av_md5_sum((uint8_t*)md5tmp, packet->data, packet->size);
       for (int i=0; i<4; i++) info->audiosum[i] ^= md5tmp[i];
     }


### PR DESCRIPTION
- Hardware transcoding fails when livepeer is sent segments with very few video frames. It works fine when running software trascoding but fails in hardware trascoding. This is caused because internal buffers of Nvidia's decoder are bigger compared to software decoder, current to solve this issue we defined [SENTINEL_MAX ](https://github.com/livepeer/lpms/blob/fb9f13d91fc2b20e51b799216c322dbfc30f07c5/ffmpeg/decoder.h#L33)= 5, but still appears issue on other GPU(i.e. 1660).
So changed  SENTINEL_MAX to 8.

- Rarely, the first audio packet is dropped during transcoding. Therefore, do not compare the first audio packets those timestamp equals 0 [here](https://github.com/livepeer/lpms/blob/fb9f13d91fc2b20e51b799216c322dbfc30f07c5/ffmpeg/extras.c#L344).