### PR TITLE
calculate similarity per audio packet

### DIFF
--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -364,10 +364,10 @@ clean:
 double get_chi_distance(struct match_info* info1, struct match_info *info2)
 {
   double chidis = 0.0;
-	for (int i = 0; i < 256; i++) {
-		chidis += ((info1->audiohis[i] - info2->audiohis[i]) ^ 2) / (double)(info1->audiohis[i] + info2->audiohis[i]);
-	}
-	chidis /= 2.0;
+  for (int i = 0; i < 256; i++) {
+    chidis += ((info1->audiohis[i] - info2->audiohis[i]) ^ 2) / (double)(info1->audiohis[i] + info2->audiohis[i]);
+  }
+  chidis /= 2.0;
   return chidis;
 }
 

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -6,7 +6,7 @@
 #include "extras.h"
 #include "logging.h"
 
-#define MIN_SIMILARITY 0.90
+#define MAX_AMISMATCH 10
 #define INC_MD5_COUNT 300
 #define MAX_MD5_COUNT 30000
 #define MD5_SIZE 16   //sizeof(int)*4 byte
@@ -379,29 +379,31 @@ clean:
   avformat_close_input(&ifmt_ctx);
   return ret;
 }
-// calculate similarity for audio md5 data
-double get_md5_similarity(struct match_info* info1, struct match_info *info2)
+// check validity for audio md5 data
+bool is_valid_md5data(struct match_info* info1, struct match_info *info2)
 {
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define min(a, b) ((a) < (b) ? (a) : (b))
-  double res = 0.0;
+  struct match_info* first = info1->apacketcount < info2->apacketcount? info1: info2;
+  struct match_info* second = info1->apacketcount >= info2->apacketcount? info1: info2;
+  int packetdiff = second->apacketcount - first->apacketcount;
+  if (packetdiff > MAX_AMISMATCH) return false;
   int matchingcount = 0;
-  for (int i = 0; i < info1->apacketcount; i++) {
-    int scanscope = i/10+10;// +- 10% scan
-    int *psrcmpd = info1->pmd5array + (i*4);
+  for (int i = 0; i < first->apacketcount; i++) {
+    int scanscope = packetdiff + 1;
+    int *psrcmpd = first->pmd5array + (i*4);
     int nstart = max(0,i-scanscope);
-    int nend = min(info2->apacketcount,i+scanscope);
+    int nend = min(second->apacketcount,i+scanscope);
     for (int j = nstart; j < nend; j++) {
-      if(memcmp(psrcmpd, info2->pmd5array + (j*4), MD5_SIZE) == 0){
+      if(memcmp(psrcmpd, second->pmd5array + (j*4), MD5_SIZE) == 0){
         matchingcount++;
         break;
       }
     }
   }
-  res = matchingcount/(double)info1->apacketcount;
-  return res;
+  int realdiff = first->apacketcount - matchingcount;
+  return realdiff < MAX_AMISMATCH ? true: false;
 }
-
 // compare two video buffers whether those matches or not.
 // @param buffer1         the pointer of the first video buffer.
 // @param buffer2         the pointer of the second video buffer.
@@ -419,7 +421,7 @@ int lpms_compare_video_bybuffer(void *buffer1, int len1, void *buffer2, int len2
   ret = get_matchinfo(buffer2,len2,&info2);
   if(ret < 0) goto clean;
   //compare two matching information
-  if (info1.width != info2.width || info1.height != info2.height || get_md5_similarity(&info1, &info2) < MIN_SIMILARITY) {
+  if (info1.width != info2.width || info1.height != info2.height || !is_valid_md5data(&info1, &info2)) {
       ret = 1;
   }
 clean:

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -16,8 +16,7 @@ struct match_info {
   int       height;
   uint64_t  bit_rate;
   int       packetcount;  //video total packet count
-  uint64_t  timestamp;    //XOR sum of avpacket pts
-  int       audiohis[256];//Histogram for audio data
+  uint64_t  timestamp;    //XOR sum of avpacket pts  
   int       md5allocsize;
   int       apacketcount; //audio packet count
   int       *pmd5array;


### PR DESCRIPTION
Occasionally, B receives different renditions that are mismatched in audio data from Ts , At this time we can see that one or two packets are missed compared to the original audio data.
I tried to explain the cause in the video transcoding pipeline, but it could not be reproduced in the local environment, appeared occasionally in the staging environment, and no weird parts were found in the source code.
So to increase accuracy in the audio mismatch problem, chi-distance based on binary data histogram was introduced, and the source was modified to determine that the audio data were the same when the data are almost similar.