### PR TITLE
Skip resolution adjustment in case of missing video track

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -860,7 +860,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		if err != nil {
 			return nil, err
 		}
-		if status == CodecStatusOk {
+		videoTrackPresent := format.Vcodec != ""
+		if status == CodecStatusOk && videoTrackPresent {
 			// We don't return error in case status != CodecStatusOk because proper error would be returned later in the logic.
 			// Like 'TranscoderInvalidVideo' or `No such file or directory` would be replaced by error we specify here.
 			// here we require input size and aspect ratio


### PR DESCRIPTION
This fix unmasks real error we are seeing on production.

Instead of `profile 360x640 size out of bounds 146x146-4096x4096 input=0x0 adjusted 360x-9223372036854775808 or -9223372036854775808x640` error message we will receive `TranscoderInvalidVideo`