### PR TITLE
ffmpeg: add 'import C' where it's used

### DIFF
--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -11,6 +11,8 @@ import (
 	"github.com/livepeer/m3u8"
 )
 
+import "C"
+
 var ErrProfName = fmt.Errorf("unknown VideoProfile profile name")
 var ErrCodecName = fmt.Errorf("unknown codec name")
 

--- a/segmenter/video_segmenter.go
+++ b/segmenter/video_segmenter.go
@@ -20,6 +20,8 @@ import (
 	"github.com/livepeer/m3u8"
 )
 
+import "C"
+
 var ErrSegmenterTimeout = errors.New("SegmenterTimeout")
 var ErrSegmenter = errors.New("SegmenterError")
 var PlaylistRetryCount = 5


### PR DESCRIPTION
Essentially a no-op for this project, but it's a good practice to have `import "C"` in files that use CGO. This means that other things can be compiled with `CGO_ENABLED=0` and it won't necessarily break.