### PR TITLE
Rename profile.CRF to profile.Quality

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -697,16 +697,16 @@ func createCOutputParams(input *TranscodeOptionsIn, ps []TranscodeOptions) ([]C.
 				"preset":     "slow",
 				"tier":       "high",
 			}
-			if p.Profile.CRF != 0 {
-				if p.Profile.CRF <= 63 {
-					p.VideoEncoder.Opts["crf"] = strconv.Itoa(int(p.Profile.CRF))
+			if p.Profile.Quality != 0 {
+				if p.Profile.Quality <= 63 {
+					p.VideoEncoder.Opts["crf"] = strconv.Itoa(int(p.Profile.Quality))
 				} else {
 					glog.Warning("Cannot use CRF param, value out of range (0-63)")
 				}
 
 				// There's no direct numerical correspondence between CQ and CRF.
 				// From some experiments, it seems that setting CQ = CRF + 7 gives similar visual effects.
-				cq := p.Profile.CRF + 7
+				cq := p.Profile.Quality + 7
 				if cq <= 51 {
 					p.VideoEncoder.Opts["cq"] = strconv.Itoa(int(cq))
 				} else {

--- a/ffmpeg/videoprofile.go
+++ b/ffmpeg/videoprofile.go
@@ -98,10 +98,10 @@ type VideoProfile struct {
 	Encoder      VideoCodec
 	ColorDepth   ColorDepthBits
 	ChromaFormat ChromaSubsampling
-	// CRF is used to set CRF and CQ
+	// Quality is used to set CRF and CQ
 	// If set, then constant rate factor is used instead of constant bitrate
-	// If both CRF and Bitrate are set, then Bitrate is used only as max bitrate
-	CRF uint
+	// If both Quality and Bitrate are set, then Bitrate is used only as max bitrate
+	Quality uint
 }
 
 // Some sample video profiles
@@ -235,7 +235,7 @@ type JsonProfile struct {
 	Encoder      string            `json:"encoder"`
 	ColorDepth   ColorDepthBits    `json:"colorDepth"`
 	ChromaFormat ChromaSubsampling `json:"chromaFormat"`
-	CRF          uint              `json:"crf"`
+	Quality      uint              `json:"quality"`
 }
 
 func ParseProfilesFromJsonProfileArray(profiles []JsonProfile) ([]VideoProfile, error) {
@@ -281,7 +281,7 @@ func ParseProfilesFromJsonProfileArray(profiles []JsonProfile) ([]VideoProfile, 
 			ColorDepth:   profile.ColorDepth,
 			// profile.ChromaFormat of 0 is default ChromaSubsampling420
 			ChromaFormat: profile.ChromaFormat,
-			CRF:          profile.CRF,
+			Quality:      profile.Quality,
 		}
 		parsedProfiles = append(parsedProfiles, prof)
 	}


### PR DESCRIPTION
Since we set CQ based on the `quality`, then to avoid confusion, let's not use the `crf` name.

Discussed more in [Discord](https://discord.com/channels/423160867534929930/1140578841136484402/1149583985530380380).