### PR TITLE
Use scale_cuda in Windows

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -462,18 +462,18 @@ func configEncoder(inOpts *TranscodeOptionsIn, outOpts TranscodeOptions) (string
 			if outDev != "" {
 				upload = upload + "=device=" + outDev
 			}
-			return encoder, upload + "," + hwScale(), "super", nil
+			return encoder, upload + "," + hwScale(), hwScaleAlgo(), nil
 		}
 	case Nvidia:
 		switch outOpts.Accel {
 		case Software:
-			return encoder, hwScale(), "super", nil
+			return encoder, hwScale(), hwScaleAlgo(), nil
 		case Nvidia:
 			// If we encode on a different device from decode then need to transfer
 			if outDev != "" && outDev != inDev {
 				return "", "", "", ErrTranscoderDev // XXX not allowed
 			}
-			return encoder, hwScale(), "super", nil
+			return encoder, hwScale(), hwScaleAlgo(), nil
 		}
 	case Netint:
 		switch outOpts.Accel {
@@ -1141,6 +1141,15 @@ func hwScale() string {
 		return "scale_cuda"
 	} else {
 		return "scale_npp"
+	}
+}
+
+func hwScaleAlgo() string {
+	if runtime.GOOS == "windows" {
+		// we don't build windows binaries with CUDA SDK, so need to use the default scale algorithm
+		return ""
+	} else {
+		return "super"
 	}
 }
 


### PR DESCRIPTION
Windows binaries with CUDA SDK are not working. It's probably fixable, but I think it would require at least 1 week of work. I guess it's not worth spending time on that, so for Windows AMD64 GPU, let's use the old `scale_cuda`. That means that we'll use `scale_npp` only in Linux.