### PR TITLE
Improve VFR support

### DIFF
--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -162,6 +162,8 @@ void close_output(struct output_ctx *octx)
   octx->af.flushed = octx->vf.flushed = 0;
   octx->af.flushing = octx->vf.flushing = 0;
   octx->vf.pts_diff = INT64_MIN;
+  octx->vf.prev_frame_pts = 0;
+  octx->vf.segments_complete++;
 }
 
 void free_output(struct output_ctx *octx)

--- a/ffmpeg/filter.h
+++ b/ffmpeg/filter.h
@@ -19,6 +19,12 @@ struct filter_ctx {
   // uniformly and monotonically increasing.
   int64_t custom_pts;
 
+  // Previous PTS to be used to manually calculate duration for custom_pts
+  int64_t prev_frame_pts;
+
+  // Count of complete segments that have been processed by this filtergraph
+  int segments_complete;
+
   // We need to update the post-filtergraph PTS before sending the frame for
   // encoding because we modified the input PTS.
   // We do this by calculating the difference between our custom PTS and actual


### PR DESCRIPTION
#### Improve VFR support ( 55a5d805d32927d3e6433a64fa1ad343b1370e61 )
Manually calculate the duration of each frame and set
the PTS to that before submitting to the filtergraph.

This allows us to better support variable frame rates,
and is also better aligned with how ffmpeg does it.

This may change the number of frames output by the FPS
filter by +/- 1 frame. These aren't issues in themselves
but breaks a lot of test cases which will need to be updated.

#### Update testcases for VFR ( 1986cd4f47416c8ce2af09f893e902efe3ac8898 )

#### Notes

Previously we were depending on a calculated frame rate ([r_frame_rate](https://github.com/FFmpeg/FFmpeg/blob/dd5f665b4010f8a0142ce3cba3305b173eb37dfe/libavformat/avformat.h#L903-L911))
but this isn't set to a sensible value for VFR streams. Packet duration also
can't be relied on (see the new VFR test case where each duration is N/A),
so we need to do some manual bookkeeping to calculate the timestamp
difference between frames ourselves.

I haven't yet fully understood what happens with the FPS filter during the
transition between segments but the behavior seems okay and the
timestamps don't change too much, aside from the +/- 1 frame difference.

Most unit tests pass on my machine, except I did not test GPU or non-H264
codecs. I don't *think* things would be much different there, but someone with
a GPU should check. The tests in `ffmpeg/sign_test.go` all timed out for me
and there is a segmenter test that seems flaky, but these are probably unrelated.