### PR TITLE
feat(ai): add AI video ffmpeg requirements

### DIFF
--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -338,8 +338,12 @@ int open_input(input_params *params, struct input_ctx *ctx)
   ctx->transmuxing = params->transmuxing;
 
   // open demuxer
-  ret = avformat_open_input(&ic, inp, NULL, NULL);
+  AVDictionary **demuxer_opts = NULL;
+  if (params->demuxer.opts) demuxer_opts = &params->demuxer.opts;
+  ret = avformat_open_input(&ic, inp, NULL, demuxer_opts);
   if (ret < 0) LPMS_ERR(open_input_err, "demuxer: Unable to open input");
+  // If avformat_open_input replaced the options AVDictionary with options that were not found free it
+  if (demuxer_opts) av_dict_free(demuxer_opts);
   ctx->ic = ic;
   ret = avformat_find_stream_info(ic, NULL);
   if (ret < 0) LPMS_ERR(open_input_err, "Unable to find input info");

--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -337,7 +337,7 @@ int open_input(input_params *params, struct input_ctx *ctx)
 
   ctx->transmuxing = params->transmuxing;
 
-  // open demuxer
+  // open demuxer/ open demuxer
   AVDictionary **demuxer_opts = NULL;
   if (params->demuxer.opts) demuxer_opts = &params->demuxer.opts;
   ret = avformat_open_input(&ic, inp, NULL, demuxer_opts);

--- a/ffmpeg/extras.c
+++ b/ffmpeg/extras.c
@@ -164,6 +164,9 @@ int lpms_get_codec_info(char *fname, pcodec_info out)
     // instead of returning -1
     ret = GET_CODEC_STREAMS_MISSING;
   }
+  if (ic->duration != AV_NOPTS_VALUE) {
+    out->dur = ic->duration / AV_TIME_BASE;
+  }
   // Return
   if (video_present && vc->name) {
       strncpy(out->video_codec, vc->name, MIN(strlen(out->video_codec), strlen(vc->name))+1);
@@ -176,6 +179,7 @@ int lpms_get_codec_info(char *fname, pcodec_info out)
       }
       out->width  = ic->streams[vstream]->codecpar->width;
       out->height = ic->streams[vstream]->codecpar->height;
+      out->fps = av_q2d(ic->streams[vstream]->r_frame_rate);
   } else {
       // Indicate failure to extract video codec from given container
       out->video_codec[0] = 0;

--- a/ffmpeg/extras.h
+++ b/ffmpeg/extras.h
@@ -7,6 +7,8 @@ typedef struct s_codec_info {
   int    pixel_format;
   int    width;
   int    height;
+  double fps;
+  double dur;
 } codec_info, *pcodec_info;
 
 int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char *seg_start);

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -245,6 +245,8 @@ type MediaFormatInfo struct {
 	Acodec, Vcodec string
 	PixFormat      PixelFormat
 	Width, Height  int
+	FPS            float32
+	DurSecs        int64
 }
 
 func (f *MediaFormatInfo) ScaledHeight(width int) int {
@@ -277,6 +279,8 @@ func GetCodecInfo(fname string) (CodecStatus, MediaFormatInfo, error) {
 	format.PixFormat = PixelFormat{int(params_c.pixel_format)}
 	format.Width = int(params_c.width)
 	format.Height = int(params_c.height)
+	format.FPS = float32(params_c.fps)
+	format.DurSecs = int64(params_c.dur)
 	return status, format, nil
 }
 
@@ -979,7 +983,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 				input.Profile.FramerateDen = 1
 			}
 
-			// Do not try tofree in this function because in the C code avformat_open_input()
+			// Do not try to free in this function because in the C code avformat_open_input()
 			// will destroy this
 			demuxerOpts.opts = newAVOpts(map[string]string{
 				"framerate": fmt.Sprintf("%d/%d", input.Profile.Framerate, input.Profile.FramerateDen),

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -850,6 +850,19 @@ func destroyCOutputParams(params []C.output_params) {
 	}
 }
 
+func hasVideoMetadata(fname string) bool {
+	if strings.HasPrefix(strings.ToLower(fname), "pipe:") {
+		return false
+	}
+
+	fileInfo, err := os.Stat(fname)
+	if err != nil {
+		return false
+	}
+
+	return !fileInfo.IsDir()
+}
+
 func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions) (*TranscodeResults, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -861,8 +874,8 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 	}
 	var reopendemux bool
 	reopendemux = false
-	// don't read metadata for pipe input, because it can't seek back and av_find_input_format in the decoder will fail
-	if !strings.HasPrefix(strings.ToLower(input.Fname), "pipe:") {
+	// don't read metadata for inputs without video metadata, because it can't seek back and av_find_input_format in the decoder will fail
+	if hasVideoMetadata(input.Fname) {
 		status, format, err := GetCodecInfo(input.Fname)
 		if err != nil {
 			return nil, err

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -51,6 +51,8 @@ typedef struct {
   char *device;
   char *xcoderParams;
 
+  // Optional demuxer opts
+  component_opts demuxer;
   // Optional video decoder + opts
   component_opts video;
 

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -209,13 +209,13 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
     --enable-libx264 --enable-gpl \
     --enable-protocol=rtmp,file,pipe \
-    --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \
+    --enable-muxer=mp3,wav,flac,mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=mp3,wav,flac,flv,mpegts,mp4,mov,webm,matroska,image2 \
     --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps,hevc_mp4toannexb,extract_extradata \
-    --enable-parser=aac,aac_latm,h264,hevc,vp8,vp9 \
+    --enable-parser=mpegaudio,vorbis,opus,flac,aac,aac_latm,h264,hevc,vp8,vp9,png \
     --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
     --enable-filter=aresample,asetnsamples,fps,scale,hwdownload,select,livepeer_dnn,signature \
-    --enable-encoder=aac,opus,libx264 \
-    --enable-decoder=aac,opus,h264 \
+    --enable-encoder=mp3,vorbis,flac,aac,opus,libx264 \
+    --enable-decoder=mp3,vorbis,flac,aac,opus,h264,png \
     --extra-cflags="${EXTRA_CFLAGS} -I${ROOT}/compiled/include -I/usr/local/cuda/include" \
     --extra-ldflags="${EXTRA_FFMPEG_LDFLAGS} -L${ROOT}/compiled/lib -L/usr/local/cuda/lib64" \
     --prefix="$ROOT/compiled" \


### PR DESCRIPTION
This pull request adds several ffmpeg features that are needed for the ai-video branch. @j0sh can we merge these into the main branch or would you rather keep them on the ai-video branch for now?

#### Features:

- ffmpeg: Use helper to check for video metadata
- ffmpeg: Support image2 demuxer**
- Add media duration to lpms_get_codec_info for GetCodecInfo (#407)
- feat(ai): enable extra audio media formats
