### PR TITLE
ffmpeg: Rescale DTS better during FPS passthrough

### DIFF
--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -373,8 +373,9 @@ static int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* oc
     if (AVMEDIA_TYPE_VIDEO == ost->codecpar->codec_type && !octx->fps.den && octx->vf.active) {
       // try to preserve source timestamps for fps passthrough.
       time_base = octx->vf.time_base;
+      int64_t pts_dts_diff = pkt->pts - pkt->dts;
       pkt->pts = (int64_t)pkt->opaque; // already in filter timebase
-      pkt->dts = av_rescale_q(pkt->dts, encoder->time_base, time_base);
+      pkt->dts = pkt->pts - av_rescale_q(pts_dts_diff, encoder->time_base, time_base);
     }
     ret = mux(pkt, time_base, octx, ost);
     if (ret < 0) goto encode_cleanup;


### PR DESCRIPTION
This mostly ensures that non-B frames have the same dts/pts.

The PTS/DTS from the encoder can be "squashed" a bit during rescaling back to the source timebase if it is used directly, due to the lower resolution of the encoder timebase. We avoid this problem with the PTS in in FPS passthrough mode by reusing the source pts, but only rescale the encoder-provided DTS back to the source timebase for some semblance of timestamp consistency. Because the DTS values are squashed, they can differ from the PTS even with non-B frames.

The DTS values are still monotonic, so the exact numbers are not really important. However, some tools use `dts == pts` as a heuristic to check for B-frames ... so help them out to avoid spurious B-frame detections.

To fix the DTS/PTS mismatch, take the difference between the encoder-provided dts/pts, rescale that difference back to the source time base, and re-calculate the dts using the source pts.

Also see https://github.com/livepeer/lpms/pull/405