### PR TITLE
ffmpeg: Clamp resolutions in filter expression

### DIFF
--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -766,7 +766,7 @@ func portraitTest(t *testing.T, input string, checkResults bool, profiles []Vide
 	return resultErr
 }
 
-func TestTranscoder_Portrait(t *testing.T) {
+func TestNvidia_Portrait(t *testing.T) {
 	hevc := VideoProfile{Name: "P240p30fps16x9", Bitrate: "600k", Framerate: 30, AspectRatio: "16:9", Resolution: "426x240", Encoder: H265}
 
 	// Usuall portrait input sample
@@ -785,6 +785,11 @@ func TestTranscoder_Portrait(t *testing.T) {
 	// We expect error
 	require.Error(t, err)
 	// Error should be `profile 250x62500 size out of bounds 146x146-4096x4096 input=16x4000 adjusted 250x62500 or 16x4096`
+}
+
+func TestNvidia_Resolution(t *testing.T) {
+	runResolutionTests_H264(t, Nvidia)
+	// TODO HEVC clamping
 }
 
 // XXX test bframes or delayed frames


### PR DESCRIPTION
This allows the transcoded resolution to be re-clamped correctly if the input resolution changes mid-segment.

As a result, we no longer need to do this clamping in golang.

Additionally, make the behavior between GPU and CPU more consistent by applying nvidia codec limits and clamping CPU transcodes.

Note that we effectively do not use the smaller side of the requested resolution. Eg, the "720" would be ignored in "1280x270"

Open question - should we error out if the requested VideoProfile resolution is under/over the codec limits, rather than implicitly clamping the resolution within the limits? Previously we were erroring out if the W/H was `<= 0` but I am not sure why we would not also error out on , say, 1x99999