### PR TITLE
Fix CUVID crash on resolution change

### DIFF
--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -33,6 +33,9 @@ struct input_ctx {
 #define SENTINEL_MAX 8
   uint16_t sentinel_count;
 
+  // Packet held while decoder is blocked and needs to drain
+  AVPacket *blocked_pkt;
+
   // Filter flush
   AVFrame *last_frame_v, *last_frame_a;
 

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -20,7 +20,7 @@ struct input_ctx {
   char *xcoderParams;
 
   // Decoder flush
-  AVPacket *first_pkt;
+  AVPacket *flush_pkt;
   int flushed;
   int flushing;
   // The diff of `packets sent - frames recv` serves as an estimate of

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -255,7 +255,11 @@ int open_output(struct output_ctx *octx, struct input_ctx *ictx)
 	if(strcmp(octx->xcoderParams,"")!=0){
 	    av_opt_set(vc->priv_data, "xcoder-params", octx->xcoderParams, 0);
 	}
-    ret = avcodec_open2(vc, codec, &octx->video->opts);
+    // copy codec options and open encoder
+    AVDictionary *opts = NULL;
+    if (octx->video->opts) av_dict_copy(&opts, octx->video->opts, 0);
+    ret = avcodec_open2(vc, codec, &opts);
+    if (opts) av_dict_free(&opts);
     if (ret < 0) LPMS_ERR(open_output_err, "Error opening video encoder");
     octx->hw_type = ictx->hw_type;
   }
@@ -338,6 +342,75 @@ int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* octx, AVS
   AVPacket *pkt = NULL;
 
   if (AVMEDIA_TYPE_VIDEO == ost->codecpar->codec_type && frame) {
+    if (encoder->width != frame->width || encoder->height != frame->height) {
+      // Frame dimensions changed so need to re-init encoder
+      const AVCodec *codec = avcodec_find_encoder_by_name(octx->video->name);
+      if (!codec) LPMS_ERR(encode_cleanup, "Unable to find encoder");
+      AVCodecContext *vc = avcodec_alloc_context3(codec);
+      if (!vc) LPMS_ERR(encode_cleanup, "Unable to alloc video encoder");
+      // copy any additional params needed from AVCodecParameters
+      AVCodecParameters *codecpar = avcodec_parameters_alloc();
+      if (!codecpar) LPMS_ERR(encode_cleanup, "Unable to alloc codec params");
+      avcodec_parameters_from_context(codecpar, encoder);
+      avcodec_parameters_to_context(vc, codecpar);
+      avcodec_parameters_free(&codecpar);
+      // manually set some additional fields
+      vc->width = frame->width;
+      vc->height = frame->height;
+      vc->time_base = encoder->time_base;
+      vc->flags = encoder->flags;
+      vc->rc_min_rate = encoder->rc_min_rate;
+      vc->rc_max_rate = encoder->rc_max_rate;
+      vc->bit_rate = encoder->bit_rate;
+      vc->rc_buffer_size = encoder->rc_buffer_size;
+      if (encoder->hw_frames_ctx) {
+        if (octx->vf.active && av_buffersink_get_hw_frames_ctx(octx->vf.sink_ctx)) {
+          vc->hw_frames_ctx =
+            av_buffer_ref(av_buffersink_get_hw_frames_ctx(octx->vf.sink_ctx));
+          if (!vc->hw_frames_ctx) {
+            LPMS_ERR(encode_cleanup, "Unable to re-alloc encoder hwframes")
+          }
+        } else {
+          vc->hw_frames_ctx = av_buffer_ref(encoder->hw_frames_ctx);
+        }
+      }
+
+      // flush old encoder
+      AVPacket *pkt = av_packet_alloc();
+      if (!pkt) LPMS_ERR(encode_cleanup, "Unable to alloc flush packet");
+      avcodec_send_frame(encoder, NULL);
+      AVRational time_base = encoder->time_base;
+      while (!ret) {
+        av_packet_unref(pkt);
+        ret = avcodec_receive_packet(encoder, pkt);
+        // TODO error handling
+        if (!ret) {
+          if (!octx->fps.den && octx->vf.active) {
+            // adjust timestamps for filter passthrough
+            time_base = octx->vf.time_base;
+            int64_t pts_dts = pkt->pts - pkt->dts;
+            pkt->pts = (int64_t)pkt->opaque; // already in filter timebase
+            pkt->dts = pkt->pts - av_rescale_q(pts_dts, encoder->time_base, time_base);
+          }
+          mux(pkt, time_base, octx, ost);
+        } else if (AVERROR_EOF != ret) {
+          av_packet_free(&pkt);
+          LPMS_ERR(encode_cleanup, "did not get eof");
+        }
+      }
+      av_packet_free(&pkt);
+      avcodec_free_context(&octx->vc);
+
+      // copy codec options and open encoder
+      AVDictionary *opts = NULL;
+      if (octx->video->opts) av_dict_copy(&opts, octx->video->opts, 0);
+      ret = avcodec_open2(vc, codec, &opts);
+      if (opts) av_dict_free(&opts);
+      if (ret < 0) LPMS_ERR(encode_cleanup, "Error opening video encoder");
+      if (octx->gop_pts_len) octx->next_kf_pts = frame->pts + octx->gop_pts_len;
+      octx->vc = vc;
+      encoder = vc;
+    }
     if (!octx->res->frames) {
       frame->pict_type = AV_PICTURE_TYPE_I;
     }

--- a/ffmpeg/encoder.c
+++ b/ffmpeg/encoder.c
@@ -332,7 +332,7 @@ reopen_out_err:
   return ret;
 }
 
-static int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* octx, AVStream* ost)
+int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* octx, AVStream* ost)
 {
   int ret = 0;
   AVPacket *pkt = NULL;

--- a/ffmpeg/encoder.h
+++ b/ffmpeg/encoder.h
@@ -12,5 +12,6 @@ void free_output(struct output_ctx *octx);
 int process_out(struct input_ctx *ictx, struct output_ctx *octx, AVCodecContext *encoder, AVStream *ost,
   struct filter_ctx *filter, AVFrame *inf);
 int mux(AVPacket *pkt, AVRational tb, struct output_ctx *octx, AVStream *ost);
+int encode(AVCodecContext* encoder, AVFrame *frame, struct output_ctx* octx, AVStream* ost);
 
 #endif // _LPMS_ENCODER_H_

--- a/ffmpeg/filter.c
+++ b/ffmpeg/filter.c
@@ -1,4 +1,5 @@
 #include "filter.h"
+#include "encoder.h"
 #include "logging.h"
 
 #include <libavfilter/buffersrc.h>
@@ -282,9 +283,45 @@ int filtergraph_write(AVFrame *inf, struct input_ctx *ictx, struct output_ctx *o
   // We have to reset the filter because we initially set the filter
   // before the decoder is fully ready, and the decoder may change HW params
   // XXX: Unclear if this path is hit on all devices
-  if (is_video && inf && inf->hw_frames_ctx && filter->hwframes &&
-      inf->hw_frames_ctx->data != filter->hwframes) {
-    free_filter(&octx->vf); // XXX really should flush filter first
+  if (is_video && inf && (
+      (inf->hw_frames_ctx && filter->hwframes &&
+        inf->hw_frames_ctx->data != filter->hwframes) ||
+      (filter->src_ctx->nb_outputs > 0 &&
+        filter->src_ctx->outputs[0]->w != inf->width &&
+        filter->src_ctx->outputs[0]->h != inf->height))) {
+
+
+    // flush video filter
+    ret = av_buffersrc_write_frame(filter->src_ctx, NULL);
+    if (ret < 0) LPMS_ERR(fg_write_cleanup, "Error closing filter for reinit");
+    while (!ret) {
+      ret = filtergraph_read(ictx, octx, filter, is_video);
+      if (AVERROR(EAGAIN) == ret || AVERROR_EOF == ret) break;
+      AVFrame *frame = filter->frame;
+      AVCodecContext *encoder = octx->vc;
+
+      // TODO does clipping need to be handled?
+      // TODO calculate signature?
+
+      // Set GOP interval if necessary
+      if (octx->gop_pts_len && frame && frame->pts >= octx->next_kf_pts) {
+        frame->pict_type = AV_PICTURE_TYPE_I;
+        octx->next_kf_pts = frame->pts + octx->gop_pts_len;
+      }
+      if (frame) {
+        // rescale pts to match encoder timebase if necessary (eg, fps passthrough)
+        AVRational filter_tb = av_buffersink_get_time_base(filter->sink_ctx);
+        if (av_cmp_q(filter_tb, encoder->time_base)) {
+          frame->pts = av_rescale_q(frame->pts, filter_tb, encoder->time_base);
+          // TODO does frame->duration needs to be rescaled too?
+        }
+      }
+      ret = encode(encoder, frame, octx, octx->oc->streams[octx->vi]);
+      if (!ret) LPMS_ERR(fg_write_cleanup, "Encoder error during filter reinit");
+    }
+    ret = 0;
+
+    free_filter(&octx->vf);
     ret = init_video_filters(ictx, octx);
     if (ret < 0) return lpms_ERR_FILTERS;
   }

--- a/ffmpeg/nvidia_test.go
+++ b/ffmpeg/nvidia_test.go
@@ -792,3 +792,7 @@ func TestTranscoder_Portrait(t *testing.T) {
 func TestNvidia_DiscontinuityAudioSegment(t *testing.T) {
 	discontinuityAudioSegment(t, Nvidia)
 }
+
+func TestNvidia_Rotation(t *testing.T) {
+	runRotationTests(t, Nvidia)
+}

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -43,7 +43,7 @@ const int lpms_ERR_UNRECOVERABLE = FFERRTAG('U', 'N', 'R', 'V');
 
 // MOVED TO decoder.[ch]
 //  Decoder: For audio, we pay the price of closing and re-opening the decoder.
-//           For video, we cache the first packet we read (input_ctx.first_pkt).
+//           For video, we cache the last keyframe read  (input_ctx.flush_pkt).
 //           The pts is set to a sentinel value and fed to the decoder. Once we
 //           receive all frames from the decoder OR have sent too many sentinel
 //           pkts without receiving anything, then we know the decoder has been
@@ -133,7 +133,7 @@ int transcode_shutdown(struct transcode_thread *h, int ret)
   ictx->flushing = 0;
   ictx->pkt_diff = 0;
   ictx->sentinel_count = 0;
-  if (ictx->first_pkt) av_packet_free(&ictx->first_pkt);
+  if (ictx->flush_pkt) av_packet_free(&ictx->flush_pkt);
   if (ictx->ac) avcodec_free_context(&ictx->ac);
   if (ictx->vc && (AV_HWDEVICE_TYPE_NONE == ictx->hw_type)) avcodec_free_context(&ictx->vc);
   for (int i = 0; i < nb_outputs; i++) {


### PR DESCRIPTION
Also adds a bunch of other changes necessary to better support
mid-stream resolution changes.

Unfortunately with CUVID there still seems to be a brief flash of
green (looks to be the length of the decoder's internal frame buffer)
but we can tackle that separately. This PR simply makes the transcoder
1) not crash, and
2) correctly encode mid-stream rotations, including with CPUs

Depends on https://github.com/livepeer/lpms/pull/417

The following commits can all stand alone except the last one (unit tests) depends on all of them. I can make separate PRs if that is preferable for ease of review. Let's also keep these commits separate when merging.

[ffmpeg: Flush filters before re-initialization.](https://github.com/livepeer/lpms/commit/dd12875e9b5ce2114b6aa1be2ae1a35f764cb296) 
Also add another condition for re-initialization: if the
input resolution changes. This triggers the filter graph
to re-build and adjust to the new resolution, when CPU
encoders are in use. Resolves a long-standing TODO.

[ffmpeg: Re-init encoder on resolution change.](https://github.com/livepeer/lpms/commit/133d1832e977d87ea63d8351a5c1e34d51c4cfd6)
Necessary to have the encoder actually pick up the new
resolution correctly.

[ffmpeg: Reset the flush packet after each keyframe.](https://github.com/livepeer/lpms/commit/26fdf8cb1af355565b9e81bea6bc9c25b6fa0587) 
This handles cases where the packet may contain a frame
that triggers a decoder reset - we do not want to cause
a reset during the flushing process.

[ffmpeg: Handle EAGAIN from decoder and drain](https://github.com/livepeer/lpms/commit/6db145ea5a96d11dd1b27200f6990ab74f3f0d18) 
This usually happens with CUVID if the decoder needs to be reset
internally for whatever reason, such as a mid-stream resolution
change. Previously, EAGAIN would loop and cause a crash.

Also block demuxing until decoder is ready to receive packets again.

[ffmpeg: Add tests for rotation.](https://github.com/livepeer/lpms/commit/986324ce939c99298c736d59f277a084bfadb0c6)