### PR TITLE
implement looping, demuxer options

### DIFF
--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -354,6 +354,7 @@ int open_input(input_params *params, struct input_ctx *ctx)
   int ret = 0;
 
   ctx->transmuxing = params->transmuxing;
+  ctx->loop = params->loop;
 
   // open demuxer/ open demuxer
   AVDictionary **demuxer_opts = NULL;

--- a/ffmpeg/decoder.h
+++ b/ffmpeg/decoder.h
@@ -52,6 +52,8 @@ struct input_ctx {
   // Transmuxing mode. Close output in lpms_transcode_stop instead of
   // at the end of lpms_transcode call.
   int transmuxing;
+  // How many times should the input be looped? -1 for forever.
+  int loop;
   // In HW transcoding, demuxer is opened once and used,
   // so it is necessary to check whether the input pixel format does not change in the middle.
   enum AVPixelFormat last_format;

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -99,6 +99,7 @@ type TranscodeOptionsIn struct {
 	Transmuxing bool
 	Profile     VideoProfile
 	Demuxer     ComponentOptions
+	Loop        int
 }
 
 type TranscodeOptions struct {
@@ -982,6 +983,7 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		xcoderParams: xcoderParams,
 		handle:       t.handle,
 		demuxer:      demuxerOpts,
+		loop:         C.int(input.Loop),
 	}
 	if input.Transmuxing {
 		inp.transmuxing = 1

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -335,6 +335,19 @@ int transcode(struct transcode_thread *h,
     av_frame_unref(dframe);
     ret = process_in(ictx, dframe, ipkt, &stream_index);
     if (ret == AVERROR_EOF) {
+      // if we're to loop, mark discontinuity and seek back to 0
+      if (ictx->loop != 0) {
+        lpms_transcode_discontinuity(h);
+        ret = avformat_seek_file(ictx->ic, -1, INT64_MIN, 0, INT64_MAX, 0);
+        if (ret < 0) {
+          LPMS_WARN("loop failed");
+          return ret;
+        }
+        if (ictx->loop > 0) {
+          ictx->loop--;
+        }
+        continue;
+      }
       // no more processing, go for flushes
       break;
     }

--- a/ffmpeg/transcoder.h
+++ b/ffmpeg/transcoder.h
@@ -58,6 +58,8 @@ typedef struct {
 
   // concatenates multiple inputs into the same output
   int transmuxing;
+  // loops input n times. -1 for forever
+  int loop;
 } input_params;
 
 #define MAX_CLASSIFY_SIZE 10


### PR DESCRIPTION
So -stream_loop doesn't work when provided as a demuxer option, as it's implemented in https://github.com/FFmpeg/FFMpeg/blob/master/fftools/ffmpeg_demux.c and we handle our own demuxing. Thankfully, this seemed to be relatively easy to port over using the preexisting work that we have for handling discontinuity. Lightly tested.

Demuxer options: Pretty straightforward, follows the same syntax as the output muxer options.

My use case: I've already got a livestream being sliced up into a bunch of C2PA-signed MP4 files. But now I need to turn them back into an MKV stream. To do this I'm using a hack on top of ffmpeg's `concat` muxer, looks like this on the command line:
```
ffmpeg \
  -stream_loop -1 \
  -safe 0 \
  -protocol_whitelist file,http,https,tcp,tls \
  -i http://127.0.0.1:9090/playback/0xf081d6383777482868faa8d5534a5f1a7777bee8/concat \
  -map 0 \
  -c copy \
  -y output.mkv
```

And that concat file looks like this:
```
ffconcat version 1.0
file 'http://127.0.0.1:9090/playback/0xf081d6383777482868faa8d5534a5f1a7777bee8/latest.mp4'
file 'http://127.0.0.1:9090/playback/0xf081d6383777482868faa8d5534a5f1a7777bee8/latest.mp4'
```
And those `latest.mp4` files get 301 redirected to the correct MP4 files. Works great!