### PR TITLE
ffmpeg: Add demuxer options.

### DIFF
--- a/ffmpeg/decoder.c
+++ b/ffmpeg/decoder.c
@@ -355,10 +355,19 @@ int open_input(input_params *params, struct input_ctx *ctx)
 
   ctx->transmuxing = params->transmuxing;
 
-  // open demuxer/ open demuxer
+  const AVInputFormat *fmt = NULL;
+  if (params->demuxer.name) {
+    fmt = av_find_input_format(params->demuxer.name);
+    if (!fmt) {
+      ret = AVERROR_DEMUXER_NOT_FOUND;
+      LPMS_ERR(open_input_err, "Invalid demuxer name")
+    }
+  }
+
+  // open demuxer
   AVDictionary **demuxer_opts = NULL;
   if (params->demuxer.opts) demuxer_opts = &params->demuxer.opts;
-  ret = avformat_open_input(&ic, inp, NULL, demuxer_opts);
+  ret = avformat_open_input(&ic, inp, fmt, demuxer_opts);
   if (ret < 0) LPMS_ERR(open_input_err, "demuxer: Unable to open input");
   // If avformat_open_input replaced the options AVDictionary with options that were not found free it
   if (demuxer_opts) av_dict_free(demuxer_opts);

--- a/ffmpeg/transcoder.c
+++ b/ffmpeg/transcoder.c
@@ -168,7 +168,15 @@ int transcode_init(struct transcode_thread *h, input_params *inp,
   if (!ictx->ic) {
     // reopen demuxer for the input segment if needed
     // XXX could open_input() be re-used here?
-    ret = avformat_open_input(&ictx->ic, inp->fname, NULL, demuxer_opts);
+    const AVInputFormat *fmt = NULL;
+    if (inp->demuxer.name) {
+      fmt = av_find_input_format(inp->demuxer.name);
+      if (!fmt) {
+        ret = AVERROR_DEMUXER_NOT_FOUND;
+        LPMS_ERR(transcode_cleanup, "Invalid demuxer name")
+      }
+    }
+    ret = avformat_open_input(&ictx->ic, inp->fname, fmt, demuxer_opts);
     if (ret < 0) LPMS_ERR(transcode_cleanup, "Unable to reopen demuxer");
     // If avformat_open_input replaced the options AVDictionary with options that were not found free it
     if (demuxer_opts) av_dict_free(demuxer_opts);


### PR DESCRIPTION
This adds demuxer options as a complement to the existing [encoder/muxer](https://github.com/livepeer/lpms/blob/ffde2327537517b3345162e9544704571bc58a34/ffmpeg/ffmpeg.go#L112-L114) options which allows us to

1. explicitly select the demuxer to use if probing doesn't return a good result, and
2. configure the demuxer with additional options

This has come up a few times while looking at various things so it is good to have an API that is fully configurable out of the box.

This was partially implemented in #420 but this is more complete - it actually allows for demuxer selection and adds test cases.