### PR TITLE
Update ffmpeg.go  change preset from slow to medium

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -671,7 +671,7 @@ func createCOutputParams(input *TranscodeOptionsIn, ps []TranscodeOptions) ([]C.
 		if len(p.VideoEncoder.Name) <= 0 && len(p.VideoEncoder.Opts) <= 0 {
 			p.VideoEncoder.Opts = map[string]string{
 				"forced-idr": "1",
-				"preset":     "slow",
+				"preset":     "medium",
 				"tier":       "high",
 			}
 			if p.Profile.Quality != 0 {


### PR DESCRIPTION
Updated the FFmpeg preset from slow to medium because the increased computation time required for slow does not provide a significant visual quality improvement. This change optimizes the balance between performance and quality.
![image](https://github.com/user-attachments/assets/1cb07773-b58f-4cb9-a208-0742c3f609ca)

