### PR TITLE
Fix crash on PNG options

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -971,6 +971,9 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 			}
 
 			// changing the input map here is maybe not great
+			if input.Demuxer.Opts == nil {
+				input.Demuxer.Opts = map[string]string{}
+			}
 			input.Demuxer.Opts["framerate"] = fmt.Sprintf("%d/%d", input.Profile.Framerate, input.Profile.FramerateDen)
 		}
 	}

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2439,3 +2439,27 @@ func TestTranscoder_DemuxerOptsError(t *testing.T) {
 	assert.Equal(t, "Invalid data found when processing input", err.Error())
 
 }
+
+func TestTranscoder_PNGDemuxerOpts(t *testing.T) {
+	// we implicitly add demuxer opts to png input that has a framerate
+	// so test those
+	run, dir := setupTest(t)
+	defer os.RemoveAll(dir)
+	cmd := `
+		ffmpeg -i $1/../transcoder/test.ts -an -frames:v 3 test-%d.png
+	`
+	run(cmd)
+	res, err := Transcode3(&TranscodeOptionsIn{
+		Fname: dir + "/test-%d.png",
+		Profile: VideoProfile{
+			Framerate:    1,
+			FramerateDen: 3,
+		},
+	}, []TranscodeOptions{{
+		Profile: P144p30fps16x9,
+		Oname:   "out.ts",
+	}})
+	assert.Nil(t, err)
+	assert.Equal(t, 3, res.Decoded.Frames)
+	assert.Equal(t, 180, res.Encoded[0].Frames)
+}


### PR DESCRIPTION
Regression from https://github.com/livepeer/lpms/pull/426, luckily caught by go-livepeer tests