### PR TITLE
 docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ To get started:
 
 - Read the [contribution guide](doc/contributing.md)
 - Check out the [open issues](https://github.com/livepeer/lpms/issues)
-- Join the #dev channel in the [Discord](https://discord.gg/uaPhtyrWsF)
+- Join the #dev channel in the [Discord](https://discord.gg/livepeer)


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
