### PR TITLE
add duration check for input files

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -33,6 +33,7 @@ var ErrTranscoderHw = errors.New("TranscoderInvalidHardware")
 var ErrTranscoderInp = errors.New("TranscoderInvalidInput")
 var ErrTranscoderClipConfig = errors.New("TranscoderInvalidClipConfig")
 var ErrTranscoderVid = errors.New("TranscoderInvalidVideo")
+var ErrTranscoderDuration = errors.New("TranscoderInvalidDuration")
 var ErrTranscoderStp = errors.New("TranscoderStopped")
 var ErrTranscoderFmt = errors.New("TranscoderUnrecognizedFormat")
 var ErrTranscoderPrf = errors.New("TranscoderUnrecognizedProfile")
@@ -879,6 +880,10 @@ func (t *Transcoder) Transcode(input *TranscodeOptionsIn, ps []TranscodeOptions)
 		status, format, err := GetCodecInfo(input.Fname)
 		if err != nil {
 			return nil, err
+		}
+		if format.DurSecs > 300 {
+			glog.Errorf("Input file %s has duration of %d seconds, which is more than 5 minutes. This is not supported by the transcoder.", input.Fname, format.DurSecs)
+			return nil, ErrTranscoderDuration
 		}
 		// TODO hoist the rest of this into C so we don't have to invoke GetCodecInfo
 		if !t.started {

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2470,9 +2470,7 @@ func TestTranscode_DurationLimit(t *testing.T) {
 	_, errBadInput := transcoder.Transcode(badInput, options)
 
 	// Check that the correct error was returned
-	if errBadInput != ErrTranscoderDuration {
-		t.Errorf("Expected ErrTranscoderDuration for video longer than 5 minutes, got %v", errBadInput)
-	}
+	assert.Equal(t, ErrTranscoderDuration, errBadInput)
 
 	// transcode good input
 	_, errGoodInput := transcoder.Transcode(goodInput, options)

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2430,8 +2430,10 @@ func TestTranscode_DurationLimit(t *testing.T) {
 	run, dir := setupTest(t)
 	defer os.RemoveAll(dir)
 	cmd := `
-		ffmpeg -f lavfi -i color=c=blue:s=1280x720 -r 1 -frames:v 301 -c:v libx264 test-dur-bad.ts
-		ffmpeg -f lavfi -i color=c=blue:s=1280x720 -r 1 -frames:v 300 -c:v libx264 test-dur-good.ts
+		# generate a 1fps sample
+		ffmpeg -i $1../transcoder/test.ts -c copy -bsf:v setts=ts=N/TB_OUT/1 -frames:v 301 -y test.ts
+		# double check the sample actually has the characteristics we expect
+		ffprobe -show_format test.ts  | grep duration=301.00
 	`
 	run(cmd)
 

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2431,7 +2431,7 @@ func TestTranscode_DurationLimit(t *testing.T) {
 	defer os.RemoveAll(dir)
 	cmd := `
 		# generate a 1fps sample
-		ffmpeg -i $1../transcoder/test.ts -c copy -bsf:v setts=ts=N/TB_OUT/1 -frames:v 301 -y test.ts
+		ffmpeg -i "$1"/../transcoder/test.ts -an -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
 		# double check the sample actually has the characteristics we expect
 		ffprobe -show_format test.ts  | grep duration=301.00
 	`
@@ -2443,26 +2443,19 @@ func TestTranscode_DurationLimit(t *testing.T) {
 
 	// Set up transcode options
 	badInput := &TranscodeOptionsIn{
-		Fname: fmt.Sprintf("%v/test-dur-bad.ts", dir),
+		Fname: fmt.Sprintf("%v/test.ts", dir),
 		Accel: Software,
 	}
-
-	goodInput := &TranscodeOptionsIn{
-		Fname: fmt.Sprintf("%v/test-dur-good.ts", dir),
-		Accel: Software,
-	}
-
 	profiles := []VideoProfile{
 		{
 			Name:       "test_profile",
-			Resolution: "854x480",
+			Resolution: "16x16",
 			Bitrate:    "1000k",
 		},
 	}
-
 	options := []TranscodeOptions{
 		{
-			Oname:   fmt.Sprintf("%s/out-test-dur.ts", dir),
+			Oname:   fmt.Sprintf("%s/out-test.ts", dir),
 			Profile: profiles[0],
 			Accel:   Software,
 		},
@@ -2473,28 +2466,26 @@ func TestTranscode_DurationLimit(t *testing.T) {
 
 	// Check that the correct error was returned
 	assert.Equal(t, ErrTranscoderDuration, errBadInput)
-
-	// transcode good input
-	_, errGoodInput := transcoder.Transcode(goodInput, options)
-
-	// Check that the correct error was returned
-	if errGoodInput != nil {
-		t.Error(errGoodInput)
-	}
 }
 
 func TestTranscoder_NoDurationLimitBytes(t *testing.T) {
 	run, dir := setupTest(t)
 	defer os.RemoveAll(dir)
 
-	cmd := `ffmpeg -f lavfi -i color=c=blue:s=1280x720 -r 1 -frames:v 301 -c:v libx264 test-dur-bad.ts`
+	cmd := `
+		# generate a 1fps sample
+		ffmpeg -i "$1"/../transcoder/test.ts -an -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
+		# double check the sample actually has the characteristics we expect
+		ffprobe -show_format test.ts  | grep duration=301.00
+	`
 	run(cmd)
+
 	// Create a transcoder instance
 	transcoder := NewTranscoder()
 	defer transcoder.StopTranscoder()
 
 	ir, iw, err := os.Pipe()
-	fname := fmt.Sprintf("%s/test-dur-bad.ts", dir)
+	fname := fmt.Sprintf("%s/test.ts", dir)
 	_, err = os.Stat(fname)
 	if err != nil {
 		t.Fatal(err)
@@ -2515,7 +2506,7 @@ func TestTranscoder_NoDurationLimitBytes(t *testing.T) {
 	profiles := []VideoProfile{
 		{
 			Name:       "test_profile",
-			Resolution: "854x480",
+			Resolution: "16x16",
 			Bitrate:    "1000k",
 		},
 	}

--- a/ffmpeg/ffmpeg_test.go
+++ b/ffmpeg/ffmpeg_test.go
@@ -2431,7 +2431,7 @@ func TestTranscode_DurationLimit(t *testing.T) {
 	defer os.RemoveAll(dir)
 	cmd := `
 		# generate a 1fps sample
-		ffmpeg -i "$1"/../transcoder/test.ts -an -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
+		ffmpeg -i "$1"/../transcoder/test.ts -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
 		# double check the sample actually has the characteristics we expect
 		ffprobe -show_format test.ts  | grep duration=301.00
 	`
@@ -2474,7 +2474,7 @@ func TestTranscoder_NoDurationLimitBytes(t *testing.T) {
 
 	cmd := `
 		# generate a 1fps sample
-		ffmpeg -i "$1"/../transcoder/test.ts -an -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
+		ffmpeg -i "$1"/../transcoder/test.ts -c copy -bsf:v setts=ts=N/TB/1 -frames:v 301 -y test.ts
 		# double check the sample actually has the characteristics we expect
 		ffprobe -show_format test.ts  | grep duration=301.00
 	`


### PR DESCRIPTION

Fix to test input segments for durations longer than 5 minutes. 

Fixes bug that created ridiculously large output segments.

[long-ts.log](https://github.com/user-attachments/files/20470410/long-ts.log)
[wrong-ts.log](https://github.com/user-attachments/files/20470411/wrong-ts.log)

cc @rickstaa 