### PR TITLE
ffmpeg: switch to scale_cuda for CUDA 13 support

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1115,21 +1114,11 @@ func ffmpegStrEscape(origStr string) string {
 }
 
 func hwScale() string {
-	if runtime.GOOS == "windows" {
-		// we don't build windows binaries with CUDA SDK, so need to use scale_cuda instead of scale_npp
-		return "scale_cuda"
-	} else {
-		return "scale_npp"
-	}
+	return "scale_cuda"
 }
 
 func hwScaleAlgo() string {
-	if runtime.GOOS == "windows" {
-		// we don't build windows binaries with CUDA SDK, so need to use the default scale algorithm
-		return ""
-	} else {
-		return "super"
-	}
+	return ""
 }
 
 func FfmpegSetLogLevel(level int) {

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -197,7 +197,9 @@ elif [[ "$GOOS" == "windows" ]]; then
   EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
 elif [[ -e "/usr/local/cuda/lib64" ]]; then
   echo "CUDA SDK detected, building with GPU support"
-  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-nonfree --enable-cuda-nvcc --enable-libnpp --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_npp,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
+  # libnpp is restructured/dropped in CUDA 13 and is otherwise nonfree;
+  # scale_cuda replaces scale_npp without needing it.
+  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-nonfree --enable-cuda-nvcc --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
 else
   echo "No CUDA SDK detected, building without GPU support"
 fi
@@ -231,6 +233,7 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
     --extra-cflags="${EXTRA_CFLAGS} -I${ROOT}/compiled/include -I/usr/local/cuda/include" \
     --extra-ldflags="${EXTRA_FFMPEG_LDFLAGS} -L${ROOT}/compiled/lib -L/usr/local/cuda/lib64" \
     --prefix="$ROOT/compiled" \
+    --nvccflags="-gencode arch=${NVCC_GENCODE_ARCH:-compute_60},code=${NVCC_GENCODE_SM:-sm_60} -O2 -std=c++11 -m64 -ptx" \
     $EXTRA_FFMPEG_FLAGS \
     $DEV_FFMPEG_FLAGS || (tail -100 ${ROOT}/ffmpeg/ffbuild/config.log && exit 1)
   # If configure fails, then print the last 100 log lines for debugging and exit.


### PR DESCRIPTION
CUDA 13 drops the ffmpeg libnpp wrappers. Switch ffmpeg to
scale_cuda (cherry-pick from eli/no-npp), and in
install_ffmpeg.sh drop --enable-libnpp, swap the
--enable-filter flag, and expose NVCC_GENCODE_ARCH/SM overrides
(13 removed compute_60).

Built against nvidia/cuda:13.0.0-devel-ubuntu22.04 with
NVCC_GENCODE_ARCH=compute_75. CUDA 11/12 unchanged with no env.
Container-built binary repackaged as a .deb installs cleanly on
ubuntu:22.04/24.04 and debian:13 (bare-metal path validated).